### PR TITLE
fix(ti): plat: ti: k3: am62l-bl1-dtb.sh: Make script more readable

### DIFF
--- a/plat/ti/k3/common/drivers/lpddr4/am62l-bl1-dtb.sh
+++ b/plat/ti/k3/common/drivers/lpddr4/am62l-bl1-dtb.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-dtb_offset=$(readelf -s $1 | grep dtb_array | tr -s " " | cut -d " " -f 3 | cut -c12-16)
-dtb_seek=$(echo "ibase=16; $dtb_offset" | bc)
-dd if=$2 of=$3 bs=1 seek=$dtb_seek conv=notrunc
+dtb_array_addr=$(readelf -s $1 | grep dtb_array | tr -s " " | cut -d " " -f 3)
+text_addr=$(readelf -s $1 | grep "\.text" | tr -s " " | cut -d " " -f 3)
+dtb_seek=$(printf "%d" $((0x$dtb_array_addr - 0x$text_addr)))
+dd if=$2 of=$3 bs=1 seek=$dtb_seek conv=notrunc status=none


### PR DESCRIPTION
Don't depend on yet another tool "bc" to simple hex to dec conversion as not every build system may have access to all the tools. Instead just subtract dtb_array offset from text base and use printfs for base conversion. While at that silence dd output by adding status=none