### PR TITLE
PENDING: fix(scmi): fix clock protocol version for parent handling

### DIFF
--- a/drivers/scmi-msg/clock.c
+++ b/drivers/scmi-msg/clock.c
@@ -280,7 +280,7 @@ static void scmi_clock_parent_get(struct scmi_msg *msg)
 		.status = SCMI_SUCCESS,
 	};
 	unsigned int clock_id = 0U;
-	unsigned int parent_id = 0U;
+	int32_t ret = 0U;
 
 	if (msg->in_size != sizeof(*in_args)) {
 		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
@@ -294,14 +294,12 @@ static void scmi_clock_parent_get(struct scmi_msg *msg)
 		return;
 	}
 
-	parent_id = plat_scmi_clock_get_parent(msg->agent_id, clock_id);
+	ret = plat_scmi_clock_get_parent(msg->agent_id, clock_id);
 
-	if (!parent_id)
-		return_values.status = SCMI_NOT_FOUND;
-	else if (parent_id < 0)
-		return_values.status = SCMI_NOT_SUPPORTED;
-
-	return_values.parent_id = (uint32_t)parent_id;
+	if (ret < 0)
+		return_values.status = ret;
+	else
+		return_values.parent_id = (uint32_t)ret;
 
 	scmi_write_response(msg, &return_values, sizeof(return_values));
 }
@@ -398,8 +396,8 @@ static void scmi_clock_config_set(struct scmi_msg *msg)
 	/* This breaks compatibility between version */
 	/*
 	 * if (msg->in_size != sizeof(*in_args)) {
-	 * 	scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
-	 * 	return;
+	 *	scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+	 *	return;
 	 * }
 	 */
 

--- a/drivers/scmi-msg/clock.h
+++ b/drivers/scmi-msg/clock.h
@@ -11,7 +11,7 @@
 
 #include <lib/utils_def.h>
 
-#define SCMI_PROTOCOL_VERSION_CLOCK	0x20001U
+#define SCMI_PROTOCOL_VERSION_CLOCK	0x30000U
 
 /*
  * Identifiers of the SCMI Clock Management Protocol commands
@@ -106,7 +106,7 @@ struct scmi_clock_config_set_a2p {
 	uint32_t clock_id;
 	uint32_t attributes;
 /*
- * #if SCMI_PROTOCOL_VERSION_CLOCK >= 0x20001U
+ * #if SCMI_PROTOCOL_VERSION_CLOCK >= 0x30000U
  * 	uint32_t oem_config_val;
  * #endif
  */

--- a/plat/ti/k3/common/drivers/scmi/scmi_clock.c
+++ b/plat/ti/k3/common/drivers/scmi/scmi_clock.c
@@ -156,7 +156,7 @@ int32_t plat_scmi_clock_get_possible_parents(unsigned int agent_id,
 
 	clock = ti_scmi_get_clock(agent_id, scmi_id);
 	if (clock == 0)
-		return 0;
+		return SCMI_NOT_FOUND;
 
 	*nb_elts = (uint64_t)scmi_handler_clock_get_num_clock_parents(clock->dev_id,
 									clock->clock_id);
@@ -179,15 +179,16 @@ int32_t plat_scmi_clock_get_parent(unsigned int agent_id,
 	VERBOSE("scmi_clock_get_parent agent_id = %d, scmi_id = %d\n", agent_id, scmi_id);
 	clock = ti_scmi_get_clock(agent_id, scmi_id);
 	if (clock == 0)
-		return 0;
+		return SCMI_NOT_FOUND;
 
 	status = scmi_handler_clock_get_clock_parent(clock->dev_id, clock->clock_id, &parent_id);
 	if (status)
-		parent_id = 0;
-	else
-		parent_id = parent_id - clock->clock_id - 1;
+		return SCMI_GENERIC_ERROR;
+
+	parent_id = parent_id - clock->clock_id - 1;
 
 	VERBOSE("scmi_clock_get_parent parent_id = %d\n", parent_id);
+
 	return parent_id;
 }
 
@@ -202,12 +203,12 @@ int32_t plat_scmi_clock_set_parent(unsigned int agent_id,
 		agent_id, scmi_id, parent_id);
 	clock = ti_scmi_get_clock(agent_id, scmi_id);
 	if (clock == 0)
-		return 0;
+		return SCMI_NOT_FOUND;
 
 	parent_id = parent_id + clock->clock_id + 1;
 	status = scmi_handler_clock_set_clock_parent(clock->dev_id, clock->clock_id, parent_id);
 	if (status)
-		return SCMI_DENIED;
+		return SCMI_GENERIC_ERROR;
 
 	return SCMI_SUCCESS;
 }


### PR DESCRIPTION
Fix the bug where parent_id = 0 is being returned as SCMI_NOT_FOUND.

While at it, improve error handling using better SCMI error codes for get_parent and set_parent APIs.