### PR TITLE
PENDING: feat(ti): pahole optimizations in scmi_clock

### DIFF
--- a/plat/ti/k3/common/drivers/scmi/scmi_clock.h
+++ b/plat/ti/k3/common/drivers/scmi/scmi_clock.h
@@ -2,14 +2,14 @@
 #include <common.h>
 
 typedef struct ti_scmi_clock {
-	char name[64];
-	uint32_t dev_id;
-	uint8_t enable;
 	int8_t is_security;
+	uint8_t enable;
 	uint32_t clock_id;
-	unsigned long *rates;
-	uint64_t cur_rate;
+	uint32_t dev_id;
 	uint32_t enable_count;
-	const struct ti_clk_ops *clk_ops;
+	unsigned long *rates;
 	unsigned long *rate_table;
+	uint64_t cur_rate;
+	const struct ti_clk_ops *clk_ops;
+	char name[64];
 } ti_scmi_clock_t;


### PR DESCRIPTION
Arrange the elements of ti_scmi_clock struct in a way that we compact the structure by moving the data elements from the end of the struct to fill holes.

Change-Id: Iddc6f8644b87c72eff84321cee84c76588ed6050