### PR TITLE
PENDING: fix(ti): am62l: fix am62l-bl1-dtb.sh for readelf parsing issue

### DIFF
--- a/plat/ti/k3/common/drivers/lpddr4/am62l-bl1-dtb.sh
+++ b/plat/ti/k3/common/drivers/lpddr4/am62l-bl1-dtb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 dtb_array_addr=$(readelf -s $1 | grep dtb_array | tr -s " " | cut -d " " -f 3)
-text_addr=$(readelf -s $1 | grep "\.text" | tr -s " " | cut -d " " -f 3)
+text_addr=$(readelf -S $1 | grep "\.text" | tr -s " " | cut -d " " -f 6)
 dtb_seek=$(printf "%d" $((0x$dtb_array_addr - 0x$text_addr)))
 dd if=$2 of=$3 bs=1 seek=$dtb_seek conv=notrunc status=none


### PR DESCRIPTION
am62l-bl1-dtb.sh uses readelf command with "-s" option to list down the symbols. The script then greps for "\.text" region from the list of symbols.

However the readelf (GNU 2.3) command on distributions like Ubuntu 18.04, fails to list down all the symbols correctly. As a result, the obtained offset for "\.text" region is invalid data. The effect ends up with bloating of output binary.

Fix this with using a more streamline readelf command option "-S", which lists down the section headers, thereby able to parse and search for "/.text" region.