### PR TITLE
feat(ti): AM62L: SCMI: Increase shmem size

### DIFF
--- a/plat/ti/k3/common/drivers/scmi/scmi.c
+++ b/plat/ti/k3/common/drivers/scmi/scmi.c
@@ -37,7 +37,7 @@ static const char sub_vendor[] = "Instruments";
 static struct scmi_msg_channel scmi_channel[] = {
 	[0] = {
 		.shm_addr = 0x70800000,
-		.shm_size = 0x100,
+		.shm_size = 0x1000, /* 4096 bytes */
 	},
 };
 


### PR DESCRIPTION
As there is a requirement to support large scmi messages in the share memory region like possible clk parents, we need to increase it's size to 4k. As per our estimates 4k should be sufficient for theoretical maximum scmi message.

Suggested-by: Soumya Tripathy <s-tripathy@ti.com>
Change-Id: Ic31386e3596d8772e7dfc52c1f7a8002aeeef303