### PR TITLE
DNM: FROMLIST: refactor(ti): Move boot notification to tisci

### DIFF
--- a/plat/ti/k3/common/drivers/mailbox/mailbox.c
+++ b/plat/ti/k3/common/drivers/mailbox/mailbox.c
@@ -36,30 +36,6 @@ int ti_mailbox_poll_status(void)
 	return 0;
 }
 
-void ti_sci_boot_notification(void)
-{
-	uint64_t rcv_addr;
-	struct ti_sci_boot_notification_msg *boot;
-
-	if (ti_mailbox_poll_status()) {
-		ERROR("Timeout waiting for boot notification\n");
-		return;
-	}
-
-	/* consume boot notification */
-	rcv_addr = mmio_read_32(TIFS_MAILBOX_BASE1 + TIFS_MAILBOX_MSG);
-	boot = (struct ti_sci_boot_notification_msg  *)(void *)rcv_addr;
-
-		/* Check for proper response ID */
-	if (boot->hdr.type != TI_SCI_MSG_TIFS_BOOT_NOTIFICATION) {
-		ERROR("%s: Command expected 0x%x, but received 0x%x\n",
-			__func__, TI_SCI_MSG_TIFS_BOOT_NOTIFICATION,
-			boot->hdr.type);
-		return;
-	}
-	VERBOSE("%s: boot notification received from TIFS\n", __func__);
-}
-
 int ti_sci_transport_clear_rx_thread(enum k3_sec_proxy_chan_id id)
 {
 	/* Dummy function to maintain API backward compatibility */
@@ -99,14 +75,12 @@ int ti_sci_transport_recv(enum k3_sec_proxy_chan_id id, struct ti_sci_msg *msg)
 	assert( (rcv_addr < TIFS_MESSAGE_RESP_END_REGION) &&
 		(rcv_addr > TIFS_MESSAGE_RESP_START_REGION) );
 
-	num_bytes = msg->len / sizeof(uint8_t);
-	num_bytes += sizeof(struct ti_sci_secure_msg_hdr);
+	num_bytes = msg->len;
 
 	for (int i = 0; i < num_bytes; i++) {
 		((uint8_t *)msg->buf)[i] = *(uint8_t *)(rcv_addr);
 		rcv_addr += sizeof(uint8_t);
 	}
-	memmove(msg->buf, &msg->buf[sizeof(struct ti_sci_secure_msg_hdr)], msg->len);
 
 	return 0;
 }

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci.h
@@ -265,6 +265,7 @@ int ti_sci_enter_sleep(uint8_t proc_id,
 		       uint8_t mode,
 		       uint64_t core_resume_addr);
 int ti_sci_lpm_get_next_sys_mode(uint8_t *next_mode);
+int ti_sci_boot_notification(void);
 
 /**
  * - ti_sci_prepare_sleep - Command to initiate system transition into suspend.

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci_protocol.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci_protocol.h
@@ -23,6 +23,7 @@
 #define TI_SCI_MSG_GOODBYE		0x0004
 #define TI_SCI_MSG_SYS_RESET		0x0005
 #define TI_SCI_MSG_QUERY_FW_CAPS	0x0022
+#define TI_SCI_MSG_TIFS_BOOT_NOTIFICATION	U(0x000A)
 
 /* Device requests */
 #define TI_SCI_MSG_SET_DEVICE_STATE	0x0200
@@ -55,6 +56,17 @@
 #define TISCI_MSG_WAIT_PROC_BOOT_STATUS	0xc401
 
 /**
+ * struct ti_sci_secure_msg_hdr - Header that prefixes all TISCI messages sent
+ *				  via secure transport.
+ * @checksum:	crc16 checksum for the entire message
+ * @reserved:	Reserved for future use.
+ */
+struct ti_sci_secure_msg_hdr {
+	uint16_t checksum;
+	uint16_t reserved;
+} __packed;
+
+/**
  * struct ti_sci_msg_hdr - Generic Message Header for All messages and responses
  * @type:	Type of messages: One of TI_SCI_MSG* values
  * @host:	Host of the message
@@ -62,6 +74,7 @@
  * @flags:	Flag for the message
  */
 struct ti_sci_msg_hdr {
+	struct ti_sci_secure_msg_hdr sec_hdr;
 	uint16_t type;
 	uint8_t host;
 	uint8_t seq;
@@ -83,17 +96,6 @@ struct ti_sci_msg_hdr {
  */
 struct ti_sci_msg_req_version {
 	struct ti_sci_msg_hdr hdr;
-} __packed;
-
-/**
- * struct ti_sci_secure_msg_hdr - Header that prefixes all TISCI messages sent
- *				  via secure transport.
- * @checksum:	crc16 checksum for the entire message
- * @reserved:	Reserved for future use.
- */
-struct ti_sci_secure_msg_hdr {
-	uint16_t checksum;
-	uint16_t reserved;
 } __packed;
 
 /**
@@ -846,6 +848,15 @@ struct tisci_msg_min_context_restore_req {
 	struct ti_sci_msg_hdr	hdr;
 	uint32_t			ctx_lo;
 	uint32_t			ctx_hi;
+} __packed;
+
+/**
+ * struct ti_sci_boot_notification_msg - Message format for boot
+ *					       notification
+ * @hdr:		Generic message hdr
+ */
+struct ti_sci_boot_notification_msg {
+	struct ti_sci_msg_hdr hdr;
 } __packed;
 
 #endif /* TI_SCI_PROTOCOL_H */

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci_transport.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci_transport.h
@@ -9,23 +9,6 @@
 #include <stdint.h>
 #include <ti_sci_protocol.h>
 
-#define TI_SCI_MSG_TIFS_BOOT_NOTIFICATION	0x000A
-
-extern void ti_sci_boot_notification(void);
-
-/**
- * struct ti_sci_boot_notification_msg - Message format for boot
- *					       notification
- * @checksum:		Checksum for the entire message
- * @reserved:		Reserved for future use.
- * @hdr:		Generic message hdr
- */
-struct ti_sci_boot_notification_msg {
-	uint16_t checksum;
-	uint16_t reserved;
-	struct ti_sci_msg_hdr hdr;
-} __packed;
-
 /**
  * enum k3_sec_proxy_chan_id - Secure Proxy thread IDs
  *


### PR DESCRIPTION
Since boot notification is a TI SCI message move it to tisci driver. While at it, we need to also generalise the secure header at this point so we can avoid unnecessary hacks to move it around. Hence, include it as part of tisci header struct itself

Change-Id: Iea8e936772219e0c4f0e0e6ca68c2a4296e4907b

---
**This WILL break BL1.**

DO NOT MERGE AS OF YET
=======================