### PR TITLE
PENDING: fix(ti): AM62L Failed to get response error messages

### DIFF
--- a/plat/ti/k3/common/k3_bl31_setup.c
+++ b/plat/ti/k3/common/k3_bl31_setup.c
@@ -102,46 +102,16 @@ void bl31_plat_arch_setup(void)
 
 void bl31_platform_setup(void)
 {
-	struct ti_sci_msg_version version;
 	int ret;
 
 	k3_gic_driver_init(K3_GIC_BASE);
 	k3_gic_init();
 
-	ti_soc_init();
 	ti_sci_boot_notification();
 
-	ret = ti_sci_get_revision(&version);
+	ret = ti_soc_init();
 	if (ret) {
-		ERROR("Unable to communicate with the control firmware (%d)\n", ret);
-		return;
-	}
-
-	INFO("SYSFW ABI: %d.%d (firmware rev 0x%04x '%s')\n",
-	     version.abi_major, version.abi_minor,
-	     version.firmware_revision,
-	     version.firmware_description);
-
-	/*
-	 * Older firmware have a timing issue with DM that crashes few TF-A
-	 * lite devices while trying to make calls to DM. Since there is no way
-	 * to detect what current DM version we are running - we rely on the
-	 * corresponding TIFS versioning to handle this check and ensure that
-	 * the platform boots up
-	 *
-	 * Upgrading to TIFS version 9.1.7 along with the corresponding DM from
-	 * ti-linux-firmware will enable this functionality.
-	 */
-	if (version.firmware_revision > 9 ||
-	    (version.firmware_revision == 9 && version.sub_version > 1) ||
-	    (version.firmware_revision == 9 && version.sub_version == 1 &&
-		 version.patch_version >= 7)
-	) {
-		if (ti_sci_device_get(PLAT_BOARD_DEVICE_ID)) {
-			WARN("Unable to take system power reference\n");
-		}
-	} else {
-		NOTICE("Upgrade Firmwares for Power off functionality\n");
+		ERROR("Failed to initialize SOC (%d)\n", ret);
 	}
 }
 

--- a/plat/ti/k3/include/plat_private.h
+++ b/plat/ti/k3/include/plat_private.h
@@ -22,7 +22,7 @@ extern const mmap_region_t plat_k3_mmap[];
 void ti_init_scmi_server(void);
 
 /* Any kind of SOC specific init can be done here */
-void ti_soc_init(void);
+int ti_soc_init(void);
 
 #endif /* PLATFORM_PRIVATE_H */
 


### PR DESCRIPTION
Since AM62L doesn't implement the get_device in TIFS, the TI SCI message in bl31_setup is bound to return errors.
This may cause users to get alarmed as they may see errors in initial boot logs.
Inorder to fix this, let's prematurely exit the function in case of AM62L

Alternate approach considered:
We could've moved the ti_sci_get_revision and ti_sci_device_get in soc specific folders too, however the amount of refactor becomes unnecessarily huge. There will be common code across multiple soc.c files and that just reduces code reuse which doesn't seem like a cleaner option.

Change-Id: I99a65ffb8c62b7dd2007d064b8666cb37f2cefee

---

Logs:
```
[2025-03-12 16:25:13] NOTICE:  bl1_plat_arch_setup arch setup
[2025-03-12 16:25:13] NOTICE:  Booting Trusted Firmware
[2025-03-12 16:25:13] NOTICE:  BL1: v2.12.0(release):11.00.05
[2025-03-12 16:25:13] NOTICE:  BL1: Built : 15:24:01, Mar 11 2025
[2025-03-12 16:25:13] NOTICE:  lpdd4_init <--
[2025-03-12 16:25:13] NOTICE:  DDR ram size =80000000
[2025-03-12 16:25:13] NOTICE:  bl1_platform_setup DDR init done
[2025-03-12 16:25:13] NOTICE:  k3_bl1_handoff ENTERING WFI - end of bl1
[2025-03-12 16:25:14] NOTICE:  BL31: v2.12.0(release):11.00.05-2-ga7b218c5af1e
[2025-03-12 16:25:14] NOTICE:  BL31: Built : 16:23:30, Mar 12 2025
[2025-03-12 16:25:14] INFO:    GICv3 without legacy support detected.
[2025-03-12 16:25:14] INFO:    ARM GICv3 driver initialized in EL3
[2025-03-12 16:25:14] INFO:    Maximum SPI INTID supported: 991
[2025-03-12 16:25:14] INFO:    SYSFW ABI: 4.0 (firmware rev 0x000b '11.0.5-v11.00.05 (Fancy Rat)')
[2025-03-12 16:25:14] INFO:    stub copy 0x707f0000  0x80041000  0x707f6528
[2025-03-12 16:25:14] INFO:    A53 stub copy passed
[2025-03-12 16:25:14] INFO:    BL31: Initializing runtime services
[2025-03-12 16:25:14] INFO:    BL31: Preparing for EL3 exit to normal world
[2025-03-12 16:25:14] INFO:    Entry point address = 0x82000000
[2025-03-12 16:25:14] INFO:    SPSR = 0x3c9
[2025-03-12 16:25:14] ERROR:   Agent 0 Protocol 0x10 Message 0x7: not supported
[2025-03-12 16:25:14]
[2025-03-12 16:25:14] U-Boot SPL 2025.01-00271-g5eee7e4875d3 (Mar 12 2025 - 16:23:51 +0530)
[2025-03-12 16:25:14] SPL initial stack usage: 1856 bytes
[2025-03-12 16:25:14] Trying to boot from MMC2
[2025-03-12 16:25:15] ERROR:   Agent 0 Protocol 0x10 Message 0x7: not supported
[2025-03-12 16:25:15]
[2025-03-12 16:25:15]
[2025-03-12 16:25:15] U-Boot 2025.01-00271-g5eee7e4875d3 (Mar 12 2025 - 16:23:51 +0530)
[2025-03-12 16:25:15]
[2025-03-12 16:25:15] SoC:   AM62LX SR1.0 HS-FS
[2025-03-12 16:25:15] Model: Texas Instruments AM62L3 Evaluation Module
[2025-03-12 16:25:15] DRAM:  2 GiB
[2025-03-12 16:25:15] ERROR:   Agent 0 Protocol 0x10 Message 0x7: not supported
[2025-03-12 16:25:15] Core:  66 devices, 28 uclasses, devicetree: separate
[2025-03-12 16:25:15] MMC:   mmc@fa10000: 0, mmc@fa00000: 1
[2025-03-12 16:25:15] Loading Environment from nowhere... OK
[2025-03-12 16:25:15] In:    serial@2800000
[2025-03-12 16:25:15] Out:   serial@2800000
[2025-03-12 16:25:15] Err:   serial@2800000
[2025-03-12 16:25:15] Net:   eth0: ethernet@8000000port@1
[2025-03-12 16:25:17] Warning: ethernet@8000000port@2 (eth1) using random MAC address - 22:bc:0f:ad:26:82
[2025-03-12 16:25:17] , eth1: ethernet@8000000port@2
[2025-03-12 16:25:17] Hit any key to stop autoboot:  0
[2025-03-12 16:25:17] =>
```