### PR TITLE
PENDING: feat(ti): Add support for DDR4

### DIFF
--- a/plat/ti/k3/common/drivers/lpddr4/lpddr4_obj_if.c
+++ b/plat/ti/k3/common/drivers/lpddr4/lpddr4_obj_if.c
@@ -37,15 +37,6 @@ lpddr4_obj *lpddr4_getinstance(void)
 		.setlpiwakeuptime		= lpddr4_setlpiwakeuptime,
 		.geteccenable			= lpddr4_geteccenable,
 		.seteccenable			= lpddr4_seteccenable,
-		.getreducmode			= lpddr4_getreducmode,
-		.setreducmode			= lpddr4_setreducmode,
-		.getdbireadmode			= lpddr4_getdbireadmode,
-		.getdbiwritemode		= lpddr4_getdbiwritemode,
-		.setdbimode			= lpddr4_setdbimode,
-		.getrefreshrate			= lpddr4_getrefreshrate,
-		.setrefreshrate			= lpddr4_setrefreshrate,
-		.refreshperchipselect		= lpddr4_refreshperchipselect,
-		.deferredregverify		= lpddr4_deferredregverify,
 	};
 
 	return &driver;


### PR DESCRIPTION
Extend support for DDR4 in k3-wrapper for cadence driver. The wrapper reads CTL_0 register from config data to decide DDR4 or LPDDR4 initialization.

In addition, also removed some unused cadence driver functions to make additional space for bl1 logging. This should help new DDR4/LPDDR4 part integration.