### PR TITLE
PENDING: feat(ti): Add workaround for errata i2462

### DIFF
--- a/plat/ti/k3/common/drivers/pm/clock/clock.mk
+++ b/plat/ti/k3/common/drivers/pm/clock/clock.mk
@@ -12,4 +12,3 @@ BL31_SOURCES		+=	\
 				${PLAT_PATH}/common/drivers/pm/clock/clk_pll_deskew.c    \
 				${PLAT_PATH}/common/drivers/pm/clock/pll.c    \
 				${PLAT_PATH}/common/drivers/pm/clock/clk_wrapper.c    \
-				drivers/delay_timer/delay_timer.c	\

--- a/plat/ti/k3/common/plat_common.mk
+++ b/plat/ti/k3/common/plat_common.mk
@@ -78,6 +78,8 @@ K3_TI_SCI_SOURCES	+=	\
 PLAT_BL_COMMON_SOURCES	+=	\
 				lib/cpus/aarch64/cortex_a53.S		\
 				lib/cpus/aarch64/cortex_a72.S		\
+				drivers/delay_timer/generic_delay_timer.c	\
+				drivers/delay_timer/delay_timer.c	\
 				${XLAT_TABLES_LIB_SRCS}			\
 				${K3_CONSOLE_SOURCES}			\
 
@@ -86,7 +88,6 @@ BL31_SOURCES		+=	\
 				${PLAT_PATH}/common/k3_helpers.S	\
 				${PLAT_PATH}/common/k3_topology.c	\
 				${PLAT_PATH}/board/${TARGET_BOARD}/soc.c	\
-				drivers/delay_timer/generic_delay_timer.c  	\
 				${K3_GIC_SOURCES}			\
 				${K3_PSCI_SOURCES}			\
 				${K3_TI_SCI_SOURCES}			\


### PR DESCRIPTION
Whe ROM is booting stage 1 in xSPI 8D mode, a soft reset is needed so that flash to be put back in 1S mode to allow stage 2 ROM to re-enumerate flash.

This also needs support for udelay(), so enable system counter