### PR TITLE
github ci: Add build option with DEBUG

### DIFF
--- a/.github/workflows/build-ti-k3.yml
+++ b/.github/workflows/build-ti-k3.yml
@@ -38,6 +38,24 @@ jobs:
         echo $PATH
         echo $(pwd)
         make -j32 CROSS_COMPILE=aarch64-none-linux-gnu- PLAT=k3 TARGET_BOARD=am62l
+    - name: build lite DEBUG
+      run: |
+        make -j32 SPD=opteed CROSS_COMPILE=aarch64-none-linux-gnu- LOG_LEVEL=60 PLAT=k3 TARGET_BOARD=lite DEBUG=1
+    - name: build generic DEBUG
+      run: |
+        echo $PATH
+        echo $(pwd)
+        make -j32 SPD=opteed CROSS_COMPILE=aarch64-none-linux-gnu- LOG_LEVEL=60 PLAT=k3 TARGET_BOARD=generic DEBUG=1
+    - name: build j784s4 DEBUG
+      run: |
+        echo $PATH
+        echo $(pwd)
+        make -j32 SPD=opteed CROSS_COMPILE=aarch64-none-linux-gnu- LOG_LEVEL=60 PLAT=k3 TARGET_BOARD=j784s4 DEBUG=1
+    - name: build AM62L DEBUG
+      run: |
+        echo $PATH
+        echo $(pwd)
+        make -j32 CROSS_COMPILE=aarch64-none-linux-gnu- PLAT=k3 TARGET_BOARD=am62l LOG_LEVEL=60 DEBUG=1 bl31 # Specifically bl31, as BL1 won't fit
     - uses: actions/upload-artifact@v4
       with:
         name: ti-build-artifacts


### PR DESCRIPTION
Build and check all K3 platforms along with DEBUG enabled as well. The artifacts can then be used for boot testing all these platforms.

Change-Id: I0d974c14d6e7f27ab2cb5826f4dc6cdd1c5268e2