### PR TITLE
PENDING: feat(ti): increase MAX_XLAT_TABLES

### DIFF
--- a/plat/ti/k3/include/platform_def.h
+++ b/plat/ti/k3/include/platform_def.h
@@ -54,7 +54,7 @@
 #if IMAGE_BL1
 #define MAX_XLAT_TABLES		2
 #else
-#define MAX_XLAT_TABLES		4
+#define MAX_XLAT_TABLES		5
 #endif
 
 /*


### PR DESCRIPTION
Increase the MAX_XLAT_TABLES to 5 with the new entry as per mentioned commit.

Fixes: b45324936bbba464 ("PENDING: feat(ti): mmu map fuse writebuff buffer address")
Change-Id: I4ce502d540b30995015505dfdfe0beeb1f21c4e9