### PR TITLE
TI: Improve the log levels in initial printed messages

### DIFF
--- a/plat/ti/k3/board/am62l/soc.c
+++ b/plat/ti/k3/board/am62l/soc.c
@@ -33,9 +33,9 @@ const mmap_region_t plat_k3_mmap[] = {
  */
 static void ti_force_adc_parent(void)
 {
-	NOTICE("0_ADC0's parent is %d\n", plat_scmi_clock_get_parent(0, 0));
+	INFO("0_ADC0's parent is %d\n", plat_scmi_clock_get_parent(0, 0));
 	if (!plat_scmi_clock_set_parent(0, 0, 2)) {
-		NOTICE("0_ADC0's parent (after set_parent) is %d\n",
+		INFO("0_ADC0's parent (after set_parent) is %d\n",
 		       plat_scmi_clock_get_parent(0, 0));
 	} else {
 		WARN("ADC set_parent failed!\n");

--- a/plat/ti/k3/board/am62l/soc.c
+++ b/plat/ti/k3/board/am62l/soc.c
@@ -63,7 +63,7 @@ int ti_soc_init(void)
 		return ret;
 	}
 
-	INFO("SYSFW ABI: %d.%d (firmware rev 0x%04x '%s')\n",
+	NOTICE("SYSFW ABI: %d.%d (firmware rev 0x%04x '%s')\n",
 	     version.abi_major, version.abi_minor,
 	     version.firmware_revision,
 	     version.firmware_description);


### PR DESCRIPTION
TI: chore(ti): Make the SYSFW ABI version as NOTICE
TI: refactor(ti): reduce verbosity for ADC prints
