### PR TITLE
PENDING: fix(ti): Force TISCI version to be printed

### DIFF
--- a/plat/ti/k3/board/am62l/soc.c
+++ b/plat/ti/k3/board/am62l/soc.c
@@ -63,7 +63,7 @@ int ti_soc_init(void)
 		return ret;
 	}
 
-	INFO("SYSFW ABI: %d.%d (firmware rev 0x%04x '%s')\n",
+	NOTICE("SYSFW ABI: %d.%d (firmware rev 0x%04x '%s')\n",
 	     version.abi_major, version.abi_minor,
 	     version.firmware_revision,
 	     version.firmware_description);


### PR DESCRIPTION
Change the TISCI version information to be printed by default in all builds by switching it from INFO to NOTICE.