### PR TITLE
HACK: fix(ti): do the clk and dev init earlier on

### DIFF
--- a/plat/ti/k3/common/am62l_psci.c
+++ b/plat/ti/k3/common/am62l_psci.c
@@ -70,7 +70,11 @@ static int am62l_pwr_domain_on(u_register_t mpidr)
 		return PSCI_E_INTERN_FAIL;
 	}
 
-	scmi_handler_device_state_set_on(AM62LX_DEV_COMPUTE_CLUSTER0_A53_0 + core);
+	ret = scmi_handler_device_state_set_on(AM62LX_DEV_COMPUTE_CLUSTER0_A53_0 + core);
+	if (ret) {
+		ERROR("Request to set core on failed: %d\n", ret);
+		return PSCI_E_INTERN_FAIL;
+	}
 
 	return PSCI_E_SUCCESS;
 }

--- a/plat/ti/k3/common/am62l_psci.c
+++ b/plat/ti/k3/common/am62l_psci.c
@@ -167,11 +167,11 @@ static void am62l_pwr_domain_suspend(const psci_power_state_t *target_state)
 static void am62l_pwr_domain_suspend_finish(const psci_power_state_t *target_state)
 {
 	/* Initialize the console to provide early debug support */
+	ti_init_scmi_server();
 	k3_console_setup();
 	k3_config_wake_sources(false);
 	k3_gic_restore_context();
 	k3_gic_cpuif_enable();
-	ti_init_scmi_server();
 	k3_lpm_stub_copy_to_sram();
 	rtc_resume();
 }

--- a/plat/ti/k3/common/drivers/pm/device/device.c
+++ b/plat/ti/k3/common/drivers/pm/device/device.c
@@ -16,7 +16,7 @@
 /** The bitmask of currently enabled devgroups. */
 static uint32_t pm_devgroups_enabled;
 
-/** True if devices have completed deferred init. */
+
 static bool devices_rw;
 
 void pm_devgroup_set_enabled(devgrp_t groups)
@@ -29,19 +29,19 @@ bool pm_devgroup_is_enabled(devgrp_t groups)
 	return true;
 }
 
-/**
- * \brief Initialize a device
- *
- * This performs the necessary device initialization step, including syncing
- * the flags on the device with the real hardware state and calling the clock
- * init function for each clock.
- *
- * \param device
- * The device to init.
- *
- * \return
- * 0 on success, <0 on failure.
- */
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int32_t device_init(struct device *dev)
 {
 	const struct dev_data *data = get_dev_data(dev);
@@ -58,7 +58,7 @@ static int32_t device_init(struct device *dev)
 	}
 
 	if (!devices_rw) {
-		/* Defer remainder of init */
+
 		data = NULL;
 	}
 
@@ -66,13 +66,13 @@ static int32_t device_init(struct device *dev)
 		ret = soc_device_init(dev);
 	}
 
-	/* Calling these multiple times for a deferred device has no effect */
+
 	if ((data != NULL) && (ret == SUCCESS)) {
 		for (i = 0U; i < data->n_clocks; i++) {
 			device_clk_init(dev, i);
 		}
 
-		/* Calling these multiple times for a deferred device has no effect */
+
 		if (device_get_state(dev) != 0U) {
 			device_set_state(dev, DEV_POWER_ON_ENABLED_HOST_IDX, true);
 			device_set_retention(dev, true);
@@ -121,7 +121,7 @@ int32_t devices_init(void)
 				continue;
 			}
 
-			/* Translate compressed internal representation to bitfield */
+
 			if (soc_device_data_arr[idx]->pm_devgrp == PM_DEVGRP_DMSC) {
 				devgrp = DEVGRP_DMSC;
 			} else {
@@ -155,30 +155,52 @@ int32_t devices_init(void)
 	} while (!done && progress);
 
 	if (devices_rw) {
-		/* Only necessary after deferred initialization */
+
 		clk_drop_pwr_up_en();
 	}
 
-	if (progress) {
-		if (devices_rw) {
-			/* Only necessary after deferred initialization */
-			/* soc_device_init_complete(); */
+
+
+
+
+	for (idx = 0U; idx < soc_device_count; idx++) {
+        struct device *dev = &soc_devices[idx];
+        if (soc_device_data_arr[idx] == NULL ||
+            !pm_devgroup_is_enabled(soc_device_data_arr[idx]->pm_devgrp == PM_DEVGRP_DMSC ?
+                                  DEVGRP_DMSC :
+                                  BIT(soc_device_data_arr[idx]->pm_devgrp - 1U))) {
+            continue;
 		}
 
-		if (errors == false) {
-			pm_trace(TRACE_PM_ACTION_DEV_INIT, 0x0U);
-		}
 
-		ret = SUCCESS;
-	} else if (contents) {
-		/* We processed at least one device but didn't make progress */
-		ret = -EDEFER;
-	} else {
-		/* We didn't process any devices */
-		ret = SUCCESS;
+
+
+
+
+
+
+
+
+
+
+        if (dev->initialized == 0U) {
+            return -EDEFER;
 	}
+}
 
-	return ret;
+
+    if (progress) {
+        if (errors == false) {
+            pm_trace(TRACE_PM_ACTION_DEV_INIT, 0x0U);
+        }
+        ret = SUCCESS;
+    } else if (contents) {
+        ret = -EDEFER;
+    } else {
+        ret = SUCCESS;
+    }
+
+    return ret;
 }
 
 int32_t devices_init_rw(void)
@@ -188,10 +210,10 @@ int32_t devices_init_rw(void)
 	if (!devices_rw) {
 		uint32_t i;
 
-		/*
-		 * Force reinitialization of all devices to get defered
-		 * initialization.
-		 */
+
+
+
+
 		for (i = 0U; i < soc_device_count; i++) {
 			struct device *dev = &soc_devices[i];
 
@@ -200,14 +222,14 @@ int32_t devices_init_rw(void)
 
 		devices_rw = true;
 
-		/* Perform defered initialization */
+
 		ret = devices_init();
 	}
 
 	return ret;
 }
 
-/* extern void device_disable(struct device *dev, bool domain_reset); */
+
 int32_t devices_deinit(uint8_t pm_devgrp)
 {
 	int32_t ret = SUCCESS;
@@ -246,7 +268,7 @@ int32_t devices_deinit(uint8_t pm_devgrp)
 	return ret;
 }
 
-/* extern void device_clear_flags(struct device *dev); */
+
 int32_t devices_deinit_flags(void)
 {
 	int32_t ret = SUCCESS;
@@ -259,7 +281,7 @@ int32_t devices_deinit_flags(void)
 		}
 		dev = &soc_devices[i];
 		dev->exclusive = 0;
-		/* Deinitialize flags only for devices that have been set by a host */
+
 		if ((dev->flags != 0U) && (dev->initialized != 0U)) {
 			dev->flags = 0U;
 			device_clear_flags(dev);

--- a/plat/ti/k3/common/drivers/pm/device/device_process.c
+++ b/plat/ti/k3/common/drivers/pm/device/device_process.c
@@ -13,6 +13,7 @@
 #include <host_idx_mapping.h>
 #include <pm.h>
 #include <common/debug.h>
+#include <psc.h>
 
 int32_t set_device_handler(struct tisci_msg_set_device_req *msg_recv)
 {
@@ -27,6 +28,7 @@ int32_t set_device_handler(struct tisci_msg_set_device_req *msg_recv)
 	uint8_t host_id = req->hdr.host;
 	bool enable, retention;
 	int32_t ret = SUCCESS;
+	uint32_t current_device_state;
 	uint8_t host_idx;
 
 	pm_trace(TRACE_PM_ACTION_MSG_RECEIVED, TISCI_MSG_SET_DEVICE);
@@ -145,6 +147,26 @@ int32_t set_device_handler(struct tisci_msg_set_device_req *msg_recv)
 		device_set_state(dev, host_idx, enable);
 		if (!retention) {
 			device_set_retention(dev, retention);
+		}
+
+		/* Check the device state after processing device_set_state function */
+		current_device_state = device_get_state(dev);
+		if (state == TISCI_MSG_VALUE_DEVICE_SW_STATE_ON) {
+			if (current_device_state != TISCI_MSG_VALUE_DEVICE_HW_STATE_ON) {
+				ret = -EFAIL;
+			}
+		} else if ((state == TISCI_MSG_VALUE_DEVICE_SW_STATE_RETENTION) || (state == TISCI_MSG_VALUE_DEVICE_SW_STATE_AUTO_OFF)) {
+			if (current_device_state == TISCI_MSG_VALUE_DEVICE_HW_STATE_TRANS) {
+				/* Device with multiple psc's might be in transition state during the requested state is off/retention because of
+				 * some psc's sibling devices might be on which keep that psc's on, this results in mixed state of psc's
+				 * which is an exception to overcome with this exception below condition is written.
+				 */
+				if (((struct dev_data *) (get_dev_data(dev)))->soc.psc_idx != PSC_DEV_MULTIPLE) {
+					ret = -EFAIL;
+				}
+			}
+		} else {
+			ret = -EFAIL;
 		}
 	}
 

--- a/plat/ti/k3/common/drivers/pm/device/psc.c
+++ b/plat/ti/k3/common/drivers/pm/device/psc.c
@@ -647,7 +647,7 @@ uint32_t lpsc_module_get_state(struct device		*dev,
 	uint8_t state;
 	uint32_t ret;
 
-	state = (uint8_t) (psc_read(dev, PSC_MDCTL(idx)) & MDSTAT_STATE_MASK);
+	state = (uint8_t) (psc_read(dev, PSC_MDSTAT(idx)) & MDSTAT_STATE_MASK);
 
 	if (state == MDSTAT_STATE_SWRSTDISABLE) {
 		ret = 0U; /* Disabled */


### PR DESCRIPTION
In the resume sequence, we are doing the actual clk and dev init toward the end which is causing subsequent A53 turn ON operation to fail.
For now, move it to an early enough point such that the A53 secondary core is able to properly turn ON afterward.

Change-Id: Ib5f5cd3d58af2713ae5a471ccb5ffd63ba872aa6