### PR TITLE
PENDING: fix(ti): core ON/OFF while suspend resume

### DIFF
--- a/plat/ti/k3/common/am62l_psci.c
+++ b/plat/ti/k3/common/am62l_psci.c
@@ -24,6 +24,117 @@
 #include <ti_sci.h>
 #include <ti_sci_protocol.h>
 
+/*********** PROC BOOT CODE ******************/
+
+/* power domain indices */
+#define PD_MPU_CLST     4
+#define PD_MPU_CLST_CORE_0      5
+#define PD_MPU_CLST_CORE_1      6
+
+/* lpsc indices */
+#define LPSC_MAIN_MPU_CLST                      38
+#define LPSC_MAIN_MPU_CLST_PBIST        39
+#define LPSC_MAIN_MPU_CLST_CORE_0       40
+#define LPSC_MAIN_MPU_CLST_CORE_1       41
+
+#define PSC_SYNCRESETDISABLE            		(0x0)
+#define PSC_ENABLE                              (0x3)
+#define PSC_PD_OFF                                      (0x0)
+#define PSC_PD_ON                                       (0x1)
+
+#define MAIN_PSC_BASE 0x00400000
+#define MAIN_PSC_MDCTL_BASE 0x00400A00
+#define MAIN_PSC_MDSTAT_BASE 0x00400800
+#define MAIN_PSC_PDCTL_BASE 0x00400300
+#define MAIN_PSC_PDSTAT_BASE 0x00400200
+#define MAIN_PSC_PTSTAT (MAIN_PSC_BASE + PSC_PTSTAT)
+#define MAIN_PSC_PTCMD (MAIN_PSC_BASE + PSC_PTCMD)
+
+#define PSC_PTCMD               0x120
+#define PSC_PTCMD_H             0x124
+#define PSC_PTSTAT              0x128
+#define PSC_PTSTAT_H            0x12C
+#define PSC_PDSTAT              0x200
+#define PSC_PDCTL               0x300
+#define PSC_MDSTAT              0x800
+#define PSC_MDCTL               0xa00
+
+#define PDCTL_STATE_MASK                0x1
+#define PDCTL_STATE_OFF                 0x0
+#define PDCTL_STATE_ON                  0x1
+
+#define MDSTAT_STATE_MASK               0x3f
+#define MDSTAT_BUSY_MASK                0x30
+#define MDSTAT_STATE_SWRSTDISABLE       0x0
+#define MDSTAT_STATE_ENABLE             0x3
+
+static void __unused set_main_psc_state(uint32_t pd_id, uint32_t md_id, uint32_t pd_state, uint32_t md_state)
+{
+	uint32_t	*mdctrl_ptr;
+	volatile uint32_t	mdctrl;
+	uint32_t	*mdstat_ptr;
+	volatile uint32_t	mdstat;
+	uint32_t	*pdctrl_ptr;
+	volatile uint32_t	pdctrl;
+	uint32_t	*pdstat_ptr;
+	volatile uint32_t	pdstat;
+	volatile uint32_t	psc_ptstat;
+	volatile uint32_t	psc_ptcmd;
+
+
+	mdctrl_ptr = (uint32_t*) (uint64_t) ((MAIN_PSC_MDCTL_BASE + (4*md_id)));
+	mdctrl = (uint32_t) *((uint32_t*)mdctrl_ptr);
+	mdstat_ptr = (uint32_t*) (uint64_t) ((MAIN_PSC_MDSTAT_BASE + (4*md_id)));
+	mdstat = (uint32_t) *((uint32_t*)mdstat_ptr);
+	pdctrl_ptr = (uint32_t*) (uint64_t) ((MAIN_PSC_PDCTL_BASE + (4*pd_id)));
+	pdctrl = (uint32_t) *((uint32_t*)pdctrl_ptr);
+	pdstat_ptr = (uint32_t*) (uint64_t) ((MAIN_PSC_PDSTAT_BASE + (4*pd_id)));
+	pdstat = (uint32_t) *((uint32_t*)pdstat_ptr);
+
+	INFO("%s: before: md_id=%d, mdstat=0x%x, pdstat=0x%x \n",__func__,md_id,mdstat,pdstat);
+
+	if (((pdstat & 0x1) == pd_state) && ((mdstat & 0x1f) == md_state))
+		return;
+
+	// wait for GOSTAT to clear
+	// may need a timeout
+	psc_ptstat = *((uint32_t*) MAIN_PSC_PTSTAT);
+
+	while ((psc_ptstat & (0x1 << pd_id)) !=0)
+		psc_ptstat = *((uint32_t*) MAIN_PSC_PTSTAT);
+
+	// Set PDCTL NEXT to new state
+	*pdctrl_ptr = (pdctrl & ~(0x1)) | pd_state;
+
+	// Set MDCTL NEXT to new state
+	*mdctrl_ptr = (mdctrl & ~(0x1f)) | md_state;
+
+	// start power transisition by setti ng PTCMD Go to 1
+	psc_ptcmd = *((uint32_t*) MAIN_PSC_PTCMD);
+	psc_ptcmd |= (0x1 << pd_id);
+
+	*((uint32_t*) MAIN_PSC_PTCMD) = psc_ptcmd;
+
+	if (!md_state)
+		return;
+
+	// wait for GOSTAT to clear
+	// may need a timeout
+	psc_ptstat = *((uint32_t*) MAIN_PSC_PTSTAT);
+	while ((psc_ptstat & (0x1 << pd_id)) !=0)
+		psc_ptstat = *((uint32_t*) MAIN_PSC_PTSTAT);
+
+	//check states
+	mdstat = (uint32_t) *((uint32_t*)mdstat_ptr);
+	pdstat = (uint32_t) *((uint32_t*)pdstat_ptr);
+
+	INFO("%s: after: md_id=%d, mdstat=0x%x, pdstat=0x%x \n",__func__,md_id,mdstat,pdstat);
+
+}
+
+
+/*********** PROC BOOT CODE ENDS******************/
+
 #define CORE_PWR_STATE(state) ((state)->pwr_domain_state[MPIDR_AFFLVL0])
 #define CLUSTER_PWR_STATE(state) ((state)->pwr_domain_state[MPIDR_AFFLVL1])
 #define SYSTEM_PWR_STATE(state) ((state)->pwr_domain_state[PLAT_MAX_PWR_LVL])
@@ -70,7 +181,7 @@ static int am62l_pwr_domain_on(u_register_t mpidr)
 		return PSCI_E_INTERN_FAIL;
 	}
 
-	scmi_handler_device_state_set_on(AM62LX_DEV_COMPUTE_CLUSTER0_A53_0 + core);
+	set_main_psc_state(PD_MPU_CLST_CORE_0 + core, LPSC_MAIN_MPU_CLST_CORE_0 + core, PSC_PD_ON, PSC_ENABLE);
 
 	return PSCI_E_SUCCESS;
 }
@@ -82,7 +193,6 @@ static void am62l_pwr_domain_off(const psci_power_state_t *target_state)
 
 	/* Prevent interrupts from spuriously waking up this cpu */
 	k3_gic_cpuif_disable();
-
 }
 
 static void __dead2 am62l_pwr_domain_off_wfi(const psci_power_state_t *target_state)
@@ -94,7 +204,8 @@ static void __dead2 am62l_pwr_domain_off_wfi(const psci_power_state_t *target_st
 	/* If our cluster is not going down we stop here */
 	if (CLUSTER_PWR_STATE(target_state) != PLAT_MAX_OFF_STATE) {
 		VERBOSE("%s: A53 CORE: %d OFF\n", __func__, core);
-		scmi_handler_device_state_set_off(AM62LX_DEV_COMPUTE_CLUSTER0_A53_0 + core);
+		/* Now queue up the core shutdown request */
+		set_main_psc_state(PD_MPU_CLST_CORE_0 + core, LPSC_MAIN_MPU_CLST_CORE_0 + core, PSC_PD_OFF, PSC_SYNCRESETDISABLE);
 	}
 
 	while (true)


### PR DESCRIPTION
Key observation: using the scmi_handler code for turn ON/OFF seems to be causing issues, possibly because the core continues to poll on it's own MDSTAT which will obviously timeout and not let the core shut down cleanly. This causes issues when we try to turn on the core on resume, it's possibly left in an unclean state and hence refuses to turn on.

Change-Id: I131b83635ea5b6080870ae1b18e5665d1e6fdd00