### PR TITLE
Fix 2nd core resume failures from LPM

### DIFF
--- a/plat/ti/k3/common/drivers/pm/device/device.c
+++ b/plat/ti/k3/common/drivers/pm/device/device.c
@@ -281,3 +281,22 @@ void devices_drop_power_up_ref(void)
 		}
 	}
 }
+
+void device_id_power_up_ref(dev_idx_t idx)
+{
+	struct device *dev = soc_devices + idx;
+
+	device_set_state(dev, DEV_POWER_ON_ENABLED_HOST_IDX, true);
+}
+
+void device_id_drop_power_up_ref(dev_idx_t idx)
+{
+	struct device *dev = soc_devices + idx;
+
+	/* Deinitialize flags only for devices that have been set by a host */
+	if ((dev->flags != 0U) && (dev->initialized != 0U)) {
+		dev->flags = 0U;
+		device_clear_flags(dev);
+		dev->initialized = 0;
+	}
+}

--- a/plat/ti/k3/common/drivers/pm/include/device.h
+++ b/plat/ti/k3/common/drivers/pm/include/device.h
@@ -458,4 +458,19 @@ int32_t devices_deinit_flags(void);
  */
 void devices_drop_power_up_ref(void);
 
+/**
+ * \brief Set the power up reference for a device.
+ *
+ * @idx: The index of the device.
+ */
+void device_id_power_up_ref(dev_idx_t idx);
+
+/**
+ * \brief Drop the power up reference for a device
+ * @idx: The index of the device
+ *
+ * Deinitialize flags only for devices that have been set by a host.
+ */
+void device_id_drop_power_up_ref(dev_idx_t idx);
+
 #endif


### PR DESCRIPTION
    Use raw LPSC operations to turn on/off cores so that we can avoid
    the timeouts coming from the DM codebase where it waits for the
    PSC states to turn OFF after initiating the turn OFF. This won't
    happend because until the core hits WFI the digital logic prevents the
    PSC to go OFF.
    Also, add device pwr up and down APIs since we want to
    use raw LPSC operations to turn ON or OFF devices.
    Use these APIs for the A53 core ops
