### PR TITLE
[RFC]: feat(ti): k3: j7200 lpm support

### DIFF
--- a/drivers/ti/ti_sci/ti_sci.c
+++ b/drivers/ti/ti_sci/ti_sci.c
@@ -1784,3 +1784,46 @@ int ti_sci_lpm_get_next_sys_mode(uint8_t *next_mode)
 
 	return 0;
 }
+
+/*
+ * ti_sci_encrypt_tfa - Ask TIFS to encrypt TFA at a specific address
+ *
+ * @unencrypted_address: Address where the TFA lies unencrypted
+ * @unencrypted_len: Size of the TFA unencrypted
+ * @encrypted_address: Address where the encrypted TFA + header will be stored
+ * @max_encrypted_len: Size of DDR region reserved for encrypted TFA and header
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_encrypt_tfa(uint64_t unencrypted_address,
+		       uint32_t unencrypted_len,
+		       uint64_t encrypted_address,
+		       uint32_t max_encrypted_len)
+{
+	struct ti_sci_msg_req_encrypt_tfa req = { 0 };
+	struct ti_sci_msg_resp_encrypt_tfa resp = { 0 };
+	struct ti_sci_xfer xfer;
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TISCI_MSG_LPM_ENCRYPT, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.unencrypted_address = unencrypted_address;
+	req.unencrypted_len = unencrypted_len;
+	req.encrypted_address = encrypted_address;
+	req.max_encrypted_len = max_encrypted_len;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	return 0;
+}

--- a/drivers/ti/ti_sci/ti_sci.h
+++ b/drivers/ti/ti_sci/ti_sci.h
@@ -280,4 +280,13 @@ int ti_sci_encrypt_tfa(uint64_t unencrypted_address,
 		       uint64_t encrypted_address,
 		       uint32_t max_encrypted_len);
 
+
+/**
+ * - ti_sci_cmd_get_suspend_controller - Command to get the suspend initiator for the LPM phase.
+ *		@cur_controller: pointer to a variable that will store the current controller
+ *
+ * Returns 0 for successful request, else returns corresponding error code on failure.
+ */
+int ti_sci_cmd_get_suspend_controller(uint8_t* cur_controller);
+
 #endif /* TI_SCI_H */

--- a/drivers/ti/ti_sci/ti_sci.h
+++ b/drivers/ti/ti_sci/ti_sci.h
@@ -258,6 +258,15 @@ int ti_sci_proc_wait_boot_status_no_wait(uint8_t proc_id,
  *
  * Return: 0 if all goes well, else appropriate error message
  *
+ * - ti_sci_encrypt_tfa - Ask TIFS to encrypt TFA at a specific address
+ *
+ *		@unencrypted_address: Address where the TFA lies unencrypted
+ *		@unencrypted_len: Size of the TFA unencrypted
+ *		@encrypted_address: Address where the encrypted TFA + header
+ *				    will be stored
+ *		@max_encrypted_len: Size of DDR region reserved for encrypted
+ *				    TFA and header
+ *
  * NOTE: for all these functions, the following are generic in nature:
  * Returns 0 for successful request, else returns corresponding error message.
  */
@@ -265,5 +274,10 @@ int ti_sci_enter_sleep(uint8_t proc_id,
 		       uint8_t mode,
 		       uint64_t core_resume_addr);
 int ti_sci_lpm_get_next_sys_mode(uint8_t *next_mode);
+
+int ti_sci_encrypt_tfa(uint64_t unencrypted_address,
+		       uint32_t unencrypted_len,
+		       uint64_t encrypted_address,
+		       uint32_t max_encrypted_len);
 
 #endif /* TI_SCI_H */

--- a/drivers/ti/ti_sci/ti_sci_protocol.h
+++ b/drivers/ti/ti_sci/ti_sci_protocol.h
@@ -784,6 +784,7 @@ struct ti_sci_msg_req_wait_proc_boot_status {
 struct ti_sci_msg_req_enter_sleep {
 	struct ti_sci_msg_hdr hdr;
 #define MSG_VALUE_SLEEP_MODE_DEEP_SLEEP 0x0
+#define MSG_VALUE_SLEEP_MODE_SOC_OFF 0x05
 	uint8_t mode;
 	uint8_t processor_id;
 	uint32_t core_resume_lo;

--- a/drivers/ti/ti_sci/ti_sci_protocol.h
+++ b/drivers/ti/ti_sci/ti_sci_protocol.h
@@ -53,6 +53,10 @@
 #define TISCI_MSG_GET_PROC_BOOT_STATUS	0xc400
 #define TISCI_MSG_WAIT_PROC_BOOT_STATUS	0xc401
 
+/* TFA encrypt/decrypt messages */
+#define TISCI_MSG_LPM_ENCRYPT		0x030F
+#define TISCI_MSG_LPM_DECRYPT		0x0310
+
 /**
  * struct ti_sci_secure_msg_hdr - Header that prefixes all TISCI messages sent
  *				  via secure transport.
@@ -809,5 +813,38 @@ struct ti_sci_msg_resp_lpm_get_next_sys_mode {
 	struct ti_sci_msg_hdr hdr;
 	uint8_t mode;
 } __packed;
+
+/**
+ * struct ti_sci_msg_req_encrypt_tfa - Request for TISCI_MSG_LPM_ENCRYPT.
+ *
+ * @hdr			Generic Header
+ * @unencrypted_address:Address where the TFA lies unencrypted
+ * @encrypted_address:	Address where the encrypted TFA + header will be stored
+ * @unencrypted_len:	Size of the TFA unencrypted
+ * @max_encrypted_len:	Size of DDR region reserved for encrypted TFA
+ *
+ * This message is to be sent when the system is going in suspend, just before
+ * TI_SCI_MSG_ENTER_SLEEP.
+ * The TIFS will then encrypt the TFA and store it in RAM, along with a private
+ * header.
+ * Upon resume, the SPL will ask TIFS to decrypt it back.
+ */
+struct ti_sci_msg_req_encrypt_tfa {
+	struct ti_sci_msg_hdr hdr;
+	uint64_t unencrypted_address;
+	uint64_t encrypted_address;
+	uint32_t unencrypted_len;
+	uint32_t max_encrypted_len;
+} __packed;
+
+/**
+* \brief Response for TISCI_MSG_LPM_ENCRYPT.
+*
+* \param hdr TISCI header to provide ACK/NAK flags to the host.
+*
+*/
+struct ti_sci_msg_resp_encrypt_tfa {
+	struct ti_sci_msg_hdr hdr;
+} __attribute__((__packed__));
 
 #endif /* TI_SCI_PROTOCOL_H */

--- a/drivers/ti/ti_sci/ti_sci_protocol.h
+++ b/drivers/ti/ti_sci/ti_sci_protocol.h
@@ -56,6 +56,7 @@
 /* TFA encrypt/decrypt messages */
 #define TISCI_MSG_LPM_ENCRYPT		0x030F
 #define TISCI_MSG_LPM_DECRYPT		0x0310
+#define TI_SCI_MSG_GET_SUSPEND_CONTROLLER 0x0313
 
 /**
  * struct ti_sci_secure_msg_hdr - Header that prefixes all TISCI messages sent
@@ -86,6 +87,10 @@ struct ti_sci_msg_hdr {
 #define TI_SCI_FLAG_REQ_ACK_ON_PROCESSED	TI_SCI_MSG_FLAG(1)
 #define TI_SCI_FLAG_RESP_GENERIC_NACK		0x0
 #define TI_SCI_FLAG_RESP_GENERIC_ACK		TI_SCI_MSG_FLAG(1)
+
+#ifdef K3_LPM_DDR_SAVE_ADDRESS
+#define TI_SCI_FLAG_REQ_FWD2DM				TI_SCI_MSG_FLAG(3)
+#endif
 	/* Additional Flags */
 	uint32_t flags;
 } __packed;
@@ -847,5 +852,22 @@ struct ti_sci_msg_req_encrypt_tfa {
 struct ti_sci_msg_resp_encrypt_tfa {
 	struct ti_sci_msg_hdr hdr;
 } __attribute__((__packed__));
+
+struct ti_sci_msg_req_get_suspend_controller {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+* \brief Response for TI_SCI_MSG_GET_SUSPEND_CONTROLLER
+*
+* \param hdr TISCI header to provide ACK/NAK flags to the host.
+* \param suspend_controller Value indicating the intiator of the LPM sequence
+*
+*/
+struct ti_sci_msg_resp_get_suspend_controller {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t suspend_controller;
+} __packed;
+
 
 #endif /* TI_SCI_PROTOCOL_H */

--- a/plat/ti/k3/board/j7200/board.mk
+++ b/plat/ti/k3/board/j7200/board.mk
@@ -10,3 +10,12 @@ $(eval $(call add_define,K3_SEC_PROXY_LITE))
 
 # System coherency is managed in hardware
 USE_COHERENT_MEM	:=	1
+
+# Address to save BL31 for suspend to RAM
+# It belongs to a reserved memory region
+# If K3_LPM_DDR_SAVE_ADDRESS is set to 0x00000000, BL31 will not save itself
+# during suspend
+K3_LPM_DDR_SAVE_ADDRESS	?=	0x00000000
+$(eval $(call add_define,K3_LPM_DDR_SAVE_ADDRESS))
+K3_LPM_DDR_MAX_SAVE_SZ	?=	0x30000
+$(eval $(call add_define,K3_LPM_DDR_MAX_SAVE_SZ))

--- a/plat/ti/k3/board/j7200/board.mk
+++ b/plat/ti/k3/board/j7200/board.mk
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023, ARM Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Define sec_proxy usage as the full prioritized communication scheme
+K3_SEC_PROXY_LITE	:=	0
+$(eval $(call add_define,K3_SEC_PROXY_LITE))
+
+# System coherency is managed in hardware
+USE_COHERENT_MEM	:=	1

--- a/plat/ti/k3/board/j7200/include/board_def.h
+++ b/plat/ti/k3/board/j7200/include/board_def.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef BOARD_DEF_H
+#define BOARD_DEF_H
+
+#include <lib/utils_def.h>
+
+/* The ports must be in order and contiguous */
+#define K3_CLUSTER0_CORE_COUNT		U(2)
+#define K3_CLUSTER1_CORE_COUNT		U(0)
+#define K3_CLUSTER2_CORE_COUNT		U(0)
+#define K3_CLUSTER3_CORE_COUNT		U(0)
+
+#define PLAT_PROC_START_ID		U(32)
+#define PLAT_PROC_DEVICE_START_ID	U(202)
+#define PLAT_CLUSTER_DEVICE_START_ID	U(3)
+#define PLAT_BOARD_DEVICE_ID		U(157)
+
+#endif /* BOARD_DEF_H */

--- a/plat/ti/k3/common/k3_psci.c
+++ b/plat/ti/k3/common/k3_psci.c
@@ -259,6 +259,13 @@ static void k3_pwr_domain_suspend_to_mode(const psci_power_state_t *target_state
 	k3_gic_cpuif_disable();
 	k3_gic_save_context();
 
+#if K3_LPM_DDR_SAVE_ADDRESS
+	/* Encrypt BL31 with its context.*/
+	ti_sci_encrypt_tfa((uint64_t)__TEXT_START__,
+			   BL31_SIZE,
+			   K3_LPM_DDR_SAVE_ADDRESS,
+			   K3_LPM_DDR_MAX_SAVE_SZ);
+#endif
 	k3_pwr_domain_off(target_state);
 
 	ti_sci_enter_sleep(proc_id, mode, k3_sec_entrypoint);
@@ -266,6 +273,9 @@ static void k3_pwr_domain_suspend_to_mode(const psci_power_state_t *target_state
 
 static void k3_pwr_domain_suspend_dm_managed(const psci_power_state_t *target_state)
 {
+#ifdef K3_LPM_DDR_SAVE_ADDRESS
+	uint8_t mode = MSG_VALUE_SLEEP_MODE_SOC_OFF;
+#else
 	uint8_t mode = MSG_VALUE_SLEEP_MODE_DEEP_SLEEP;
 	int ret;
 
@@ -274,6 +284,7 @@ static void k3_pwr_domain_suspend_dm_managed(const psci_power_state_t *target_st
 		ERROR("Failed to fetch next system mode\n");
 	}
 
+#endif
 	k3_pwr_domain_suspend_to_mode(target_state, mode);
 }
 
@@ -324,8 +335,9 @@ int plat_setup_psci_ops(uintptr_t sec_entrypoint,
 		ERROR("Unable to query firmware capabilities (%d)\n", ret);
 	}
 
-	/* If firmware does not support any known suspend mode */
-	if (!(fw_caps & (MSG_FLAG_CAPS_LPM_DEEP_SLEEP |
+	if (fw_caps & MSG_FLAG_CAPS_LPM_DM_MANAGED) {
+		k3_plat_psci_ops.pwr_domain_suspend = k3_pwr_domain_suspend_dm_managed;
+	} else if (!(fw_caps & (MSG_FLAG_CAPS_LPM_DEEP_SLEEP |
 			 MSG_FLAG_CAPS_LPM_MCU_ONLY |
 			 MSG_FLAG_CAPS_LPM_STANDBY |
 			 MSG_FLAG_CAPS_LPM_PARTIAL_IO))) {
@@ -333,8 +345,6 @@ int plat_setup_psci_ops(uintptr_t sec_entrypoint,
 		k3_plat_psci_ops.pwr_domain_suspend = NULL;
 		k3_plat_psci_ops.pwr_domain_suspend_finish = NULL;
 		k3_plat_psci_ops.get_sys_suspend_power_state = NULL;
-	} else if (fw_caps & MSG_FLAG_CAPS_LPM_DM_MANAGED) {
-		k3_plat_psci_ops.pwr_domain_suspend = k3_pwr_domain_suspend_dm_managed;
 	}
 
 	*psci_ops = &k3_plat_psci_ops;

--- a/plat/ti/k3/common/k3_psci.c
+++ b/plat/ti/k3/common/k3_psci.c
@@ -22,6 +22,7 @@
 #define SYSTEM_PWR_STATE(state) ((state)->pwr_domain_state[PLAT_MAX_PWR_LVL])
 
 uintptr_t k3_sec_entrypoint;
+uint8_t suspend_controller = UINT8_MAX;
 
 static void k3_cpu_standby(plat_local_state_t cpu_state)
 {
@@ -265,9 +266,11 @@ static void k3_pwr_domain_suspend_to_mode(const psci_power_state_t *target_state
 			   BL31_SIZE,
 			   K3_LPM_DDR_SAVE_ADDRESS,
 			   K3_LPM_DDR_MAX_SAVE_SZ);
-#endif
-	k3_pwr_domain_off(target_state);
 
+	ti_sci_cmd_get_suspend_controller(&suspend_controller);
+#endif
+
+	k3_pwr_domain_off(target_state);
 	ti_sci_enter_sleep(proc_id, mode, k3_sec_entrypoint);
 }
 


### PR DESCRIPTION
Add support for LPM_ENCRYPT message.
At suspend, BL31 with its context will be encrypted by TIFS in DDR. 
Encryption is needed so that the BL31 is not modified before entering suspend or early at resume.
Then, it will be restored at resume by a decrypt message sent by the SPL on k3 platforms.

Also added support for the GET_SUSPEND_CONTROLLER message as TFA needs to know which cpu is the suspend controller.
If the A72 cpu initiates the suspend, then we add a TI_SCI_FLAG_REQ_FWD2DM flag to the enter sleep message. 
Based on if the flag is set or not TIFS can forward the enter_sleep message to the DM firmware.