### PR TITLE
PENDING: fix(ti): vendor name should be ti

### DIFF
--- a/plat/ti/k3/common/drivers/scmi/scmi.c
+++ b/plat/ti/k3/common/drivers/scmi/scmi.c
@@ -31,8 +31,8 @@ const uint8_t ti_scmi_protocol_table[] = {
 	0,
 };
 
-static const char vendor[] = "Texas";
-static const char sub_vendor[] = "Instruments";
+static const char vendor[] = "TI";
+static const char sub_vendor[] = "";
 
 static struct scmi_msg_channel scmi_channel[] = {
 	[0] = {


### PR DESCRIPTION
Fix the usage of vendor and subvendor, and just call it TI