### PR TITLE
feat(ti): Reset DDR LPSCs during init

### DIFF
--- a/plat/ti/k3/common/drivers/lpddr4/k3-ddrss.c
+++ b/plat/ti/k3/common/drivers/lpddr4/k3-ddrss.c
@@ -537,6 +537,20 @@ set_psc_def_pll:
 	else
 		ddrss_set_pll(ddrss.ddr_freq1);
 
+	/* Disable the DDR LPSCs to start in known state */
+	ret = set_main_psc_state(PD_DDR, LPSC_MAIN_DDR_DATA_ISO_N, PSC_PD_ON, PSC_SYNCRESETDISABLE);
+	if (ret != 0)
+		return ret;
+
+	ret = set_main_psc_state(PD_DDR, LPSC_MAIN_DDR_CFG_ISO_N, PSC_PD_ON, PSC_SYNCRESETDISABLE);
+	if (ret != 0)
+		return ret;
+
+	ret = set_main_psc_state(PD_DDR, LPSC_MAIN_DDR_LOCAL, PSC_PD_OFF, PSC_SYNCRESETDISABLE);
+	if (ret != 0)
+		return ret;
+
+	/* Enable DDR LPSCs to configure the controllers */
 	ret = set_main_psc_state(PD_DDR, LPSC_MAIN_DDR_LOCAL, PSC_PD_ON, PSC_ENABLE);
 	if (ret != 0U)
 		return ret;	


### PR DESCRIPTION
Reset DDR LPSCs during initialization, so that any reconfiguration occurs from a known DDR subsystem reset state.