### PR TITLE
Am62l lpm traces update

### DIFF
--- a/plat/ti/k3/board/am62l/lpm/ddr.c
+++ b/plat/ti/k3/board/am62l/lpm/ddr.c
@@ -199,7 +199,6 @@ __wkupsramfunc int32_t put_ddr_in_rtc_lpm(void)
 	if (req_type == 0U) {
 		write_mmr_field((MAIN_PLL_MMR_BASE + (0U * 0x1000U) + ((2U * 0x4U) + 0x80U)), 0x4FU, 7U, 0U);
 	} else {
-		lpm_seq_trace_fail(0xF3);
 		return -1;
 	}
 	mmio_write_32(((WKUP_CTRL_MMR_SEC_4_BASE + DDR4_FSP_CLKCHNG_ACK)), 0x1U);
@@ -213,7 +212,6 @@ __wkupsramfunc int32_t put_ddr_in_rtc_lpm(void)
 	req_type = (mmio_read_32((WKUP_CTRL_MMR_SEC_4_BASE + CHNG_DDR4_FSP_ACK)) & 0x01U);
 	if (req_type == 0U) {
 	} else {
-		lpm_seq_trace_fail(0xF4);
 		return -2;
 	}
 	req = mmio_read_32(WKUP_CTRL_MMR_SEC_4_BASE + CHNG_DDR4_FSP_REQ);

--- a/plat/ti/k3/board/am62l/lpm/lpm_stub.c
+++ b/plat/ti/k3/board/am62l/lpm/lpm_stub.c
@@ -152,105 +152,147 @@ __wkupsramfunc void disable_main_pll(void)
  * @brief Save and disable USB LPSC
  *
  */
-__wkupsramfunc static void save_and_disable_usb_lpsc(void)
+__wkupsramfunc static int32_t save_and_disable_usb_lpsc(void)
 {
+	int32_t ret = 0;
+
 	usb0_state = psc_raw_lpsc_get_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0);
 	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0, MDCTL_STATE_DISABLE, 0);
 	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0_ISO_N, MDCTL_STATE_DISABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0_ISO_N, MDCTL_STATE_DISABLE, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	}
 
-	usb1_state = psc_raw_lpsc_get_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1);
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1, MDCTL_STATE_DISABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	if (ret == 0) {
+		usb1_state = psc_raw_lpsc_get_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1);
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1, MDCTL_STATE_DISABLE, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	}
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1_ISO_N, MDCTL_STATE_DISABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1_ISO_N, MDCTL_STATE_DISABLE, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	}
+
+	return ret;
 }
 
 /**
  * @brief Save and disable USB LPSC
  *
  */
-__wkupsramfunc static void restore_usb_lpsc(void)
+__wkupsramfunc static int32_t restore_usb_lpsc(void)
 {
+	int32_t ret;
+
 	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0, usb0_state, 0);
 	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0_ISO_N, usb0_state, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB0_ISO_N, usb0_state, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	}
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1, usb1_state, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1, usb1_state, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	}
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1_ISO_N, usb1_state, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_GP_USB1_ISO_N, usb1_state, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, GP_CORE_CTL);
+	}
+
+	return ret;
 }
 
 /**
  * @brief Disable DDR LPSC
  *
  */
-__wkupsramfunc void disable_ddr_lpsc(void)
+__wkupsramfunc int32_t disable_ddr_lpsc(void)
 {
+	int32_t ret;
+
 	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_DATA_ISO_N,
 			       MDCTL_STATE_SWRSTDISABLE, 0);
 	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_CFG_ISO_N,
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_CFG_ISO_N,
 			       MDCTL_STATE_SWRSTDISABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	}
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_LOCAL,
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_LOCAL,
 			       MDCTL_STATE_SWRSTDISABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	}
+
+	return ret;
 }
 
 /**
  * @brief Enable DDR LPSC
  *
  */
-__wkupsramfunc void enable_ddr_lpsc(void)
+__wkupsramfunc int32_t enable_ddr_lpsc(void)
 {
+	int32_t ret;
+
 	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_LOCAL,
 			       MDCTL_STATE_ENABLE, 0);
 	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_CFG_ISO_N,
-			       MDCTL_STATE_ENABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_CFG_ISO_N,
+					MDCTL_STATE_ENABLE, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	}
 
-	psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_DATA_ISO_N,
-			       MDCTL_STATE_ENABLE, 0);
-	psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
-	psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	if (ret == 0) {
+		psc_raw_lpsc_set_state(K3_MAIN_PSC_BASE, LPSC_MAIN_DDR_DATA_ISO_N,
+					MDCTL_STATE_ENABLE, 0);
+		psc_raw_pd_initiate(K3_MAIN_PSC_BASE, PD_DDR);
+		ret = psc_raw_pd_wait(K3_MAIN_PSC_BASE, PD_DDR);
+	}
+
+	return ret;
 }
 
 /**
  * @brief Restore main domain plls
  *
  */
-__wkupsramfunc void restore_main_pll(void)
+__wkupsramfunc int32_t restore_main_pll(void)
 {
 	int i;
+	int32_t ret = 0;
 
 	for (i = 0; i < num_main_plls_save_rstr; i++) {
-		pll_restore(main_plls_save_rstr[i]);
+		ret = pll_restore(main_plls_save_rstr[i]);
+		if (ret != 0) {
+			return ret;
+		}
 	}
+
+	return ret;
 }
 
 __wkupsramfunc void lpm_abort(void)

--- a/plat/ti/k3/board/am62l/lpm/lpm_stub.c
+++ b/plat/ti/k3/board/am62l/lpm/lpm_stub.c
@@ -141,10 +141,7 @@ __wkupsramfunc void disable_main_pll(void)
 	int i;
 
 	for (i = 0; i < num_main_plls_save_rstr; i++) {
-
-		lpm_seq_trace(0xD1);
 		pll_disable(main_plls_save_rstr[i]);
-		lpm_seq_trace_fail(0xD1);
 	}
 }
 
@@ -298,7 +295,6 @@ __wkupsramfunc int32_t restore_main_pll(void)
 __wkupsramfunc void lpm_abort(void)
 {
 	volatile int a = 0x1234;
-	lpm_seq_trace_fail(0xF5);
 	while (a) {
 	}
 }
@@ -351,28 +347,45 @@ __wkupsramsuspendentry void k3_lpm_stub_entry(uint32_t mode)
 {
 	if (mode == 6) {
 		/* Wait for a53_1 to turn off */
-		lpm_wait_for_secondary_core_down();
-		lpm_seq_trace(0x10);
+		if (lpm_wait_for_secondary_core_down() == false) {
+			lpm_seq_trace_fail(0x1);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x1);
+		}
 
-		lpm_sleep_wait_for_tifs_wfi();
-		lpm_seq_trace(0x20);
+		if (lpm_sleep_wait_for_tifs_wfi() == false) {
+			lpm_seq_trace_fail(0x2);	
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x2);
+		}
 
-		/*Place DDR into self-refresh */
-		put_ddr_in_rtc_lpm();
-		lpm_seq_trace(0x30);
+		/* Place DDR into self-refresh */
+		if (put_ddr_in_rtc_lpm() != 0) { 
+			lpm_seq_trace_fail(0x3);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x3);
+		}
 
-		disable_ddr_lpsc();
-		lpm_seq_trace(0x40);
+		/*	Disable the LPSCs for DDR */ 
+		if (disable_ddr_lpsc() != 0) {
+			lpm_seq_trace_fail(0x4);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x4);
+		}
 
 		save_main_pll();
-		lpm_seq_trace(0x50);
+		lpm_seq_trace(0x5);
 
 		disable_main_pll();
-		lpm_seq_trace(0x60);
+		lpm_seq_trace(0x6);
 
 		/* configure the pmic input */
 		mmio_write_32(WKUP_CTRL_MMR_SEC_5_BASE + PMCTRL_SYS, 0x0U);
-		lpm_seq_trace(0x70);
+		lpm_seq_trace(0x7);
 		dsb();
 		isb();
 
@@ -381,29 +394,46 @@ __wkupsramsuspendentry void k3_lpm_stub_entry(uint32_t mode)
 
 	} else if (mode == 0) {
 
-		/* Wait for a53_1 to turn off  */
-		lpm_wait_for_secondary_core_down();
-		lpm_seq_trace(0x10);
+		/* Wait for a53_1 to turn off */
+		if (lpm_wait_for_secondary_core_down() == false) {
+			lpm_seq_trace_fail(0x1);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x1);
+		}
 
 		/* Keep the USB LPSCs off*/
-		save_and_disable_usb_lpsc();
-		lpm_seq_trace(0x11);
+		if (save_and_disable_usb_lpsc() != 0) {
+			lpm_seq_trace_fail(0x8);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x8);
+		}
 
 		save_main_pll();
-		lpm_seq_trace(0x20);
+		lpm_seq_trace(0x5);
 
-		save_ddr_reg_configs();
-		lpm_seq_trace(0x30);
+		if (save_ddr_reg_configs() != 0) {
+			lpm_seq_trace_fail(0x9);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x9);
+		}
 
-		disable_ddr_lpsc();
-		lpm_seq_trace(0x40);
+		/*	Disable the LPSCs for DDR */ 
+		if (disable_ddr_lpsc() != 0) {
+			lpm_seq_trace_fail(0x4);
+			lpm_abort();
+		} else {
+			lpm_seq_trace(0x4);
+		}
 
 		disable_main_pll();
-		lpm_seq_trace(0x50);
+		lpm_seq_trace(0x6);
 
 		dsb();
 		isb();
-		lpm_seq_trace(0x60);
+		lpm_seq_trace(0xA);
 
 		for (;;) {
 			wfi();
@@ -512,24 +542,40 @@ __wkupsramfunc void mailbox_send_message(void)
 
 __wkupsramfunc void k3_lpm_resume_c(void)
 {
-	lpm_seq_trace(0x70);
-	restore_main_pll();
+	if (restore_main_pll() != 0) {
+		lpm_seq_trace_fail(0xB);
+		lpm_abort();
+	} else {
+		lpm_seq_trace(0xB);
+	}
 
-	lpm_seq_trace(0x80);
-	enable_ddr_lpsc();
+	if (enable_ddr_lpsc() != 0) {
+		lpm_seq_trace_fail(0xC);
+		lpm_abort();
+	} else {
+		lpm_seq_trace(0xC);
+	}
 
-	lpm_seq_trace(0x90);
-	restore_ddr_reg_configs();
+	if (restore_ddr_reg_configs() != 0) {
+		lpm_seq_trace_fail(0xD);
+		lpm_abort();
+	} else {
+		lpm_seq_trace(0xD);
+	}
 
-	lpm_seq_trace(0x91);
-	restore_usb_lpsc();
+	if (restore_usb_lpsc() != 0) { 
+		lpm_seq_trace_fail(0xE);
+		lpm_abort();
+	} else {
+		lpm_seq_trace(0xE);
+	}
 
-	lpm_seq_trace(0xA0);
 	mailbox_send_message();
+	lpm_seq_trace(0xF);
 
 	for (;;) {
 		wfi();
-		lpm_seq_trace(0xB0);
+		lpm_seq_trace(0x10);
 	}
 }
 

--- a/plat/ti/k3/board/am62l/lpm/lpm_trace.h
+++ b/plat/ti/k3/board/am62l/lpm/lpm_trace.h
@@ -8,6 +8,7 @@
 #define __LPM_TRACE_H__
 
 #include <plat/common/platform.h>
+#include <common/debug.h>
 
 /**
  * \brief Outputs uint32_t trace debug value to configured trace destinations.
@@ -23,20 +24,30 @@ __wkupsramfunc void lpm_trace_debug(uint32_t value);
 	#define TRACE_PM_ACTION_LPM_SEQUENCE		0x30U
 	#define TRACE_DEBUG_ACTION_SHIFT		22U
 	#define TRACE_PM_ACTION_FAIL			0x40U
-	#define lpm_seq_trace(step) lpm_trace_debug((TRACE_DEBUG_CHANNEL_LPM << TRACE_DEBUG_DOMAIN_SHIFT) \
+
+	#if LOG_LEVEL >= LOG_LEVEL_INFO
+		#define lpm_seq_trace(step) lpm_trace_debug((TRACE_DEBUG_CHANNEL_LPM << TRACE_DEBUG_DOMAIN_SHIFT) \
 								| (((uint32_t)TRACE_PM_ACTION_LPM_SEQUENCE) << TRACE_DEBUG_ACTION_SHIFT) \
 								| (((uint32_t)step) << TRACE_PM_ACTION_LPM_SEQ_SHIFT)			\
 								| (0U))
 
-	#define lpm_seq_trace_fail(step) lpm_trace_debug((TRACE_DEBUG_CHANNEL_LPM << TRACE_DEBUG_DOMAIN_SHIFT) \
-								| (((uint32_t)TRACE_PM_ACTION_LPM_SEQUENCE | TRACE_PM_ACTION_FAIL) << TRACE_DEBUG_ACTION_SHIFT)  \
-								| (((uint32_t)step) << TRACE_PM_ACTION_LPM_SEQ_SHIFT)		     \
-								| (0U))
-
-	#define lpm_seq_trace_val(step, val) lpm_trace_debug((TRACE_DEBUG_CHANNEL_LPM << TRACE_DEBUG_DOMAIN_SHIFT) \
+		#define lpm_seq_trace_val(step, val) lpm_trace_debug((TRACE_DEBUG_CHANNEL_LPM << TRACE_DEBUG_DOMAIN_SHIFT) \
 								| (((uint32_t)TRACE_PM_ACTION_LPM_SEQUENCE) << TRACE_DEBUG_ACTION_SHIFT)  \
 								| (((uint32_t)step) << TRACE_PM_ACTION_LPM_SEQ_SHIFT) \
 								| (val))
+	#else
+		#define lpm_seq_trace(step)
+		#define lpm_seq_trace_val(step, val)
+	#endif
+
+	#if LOG_LEVEL >= LOG_LEVEL_ERROR
+		#define lpm_seq_trace_fail(step) lpm_trace_debug((TRACE_DEBUG_CHANNEL_LPM << TRACE_DEBUG_DOMAIN_SHIFT) \
+								| (((uint32_t)TRACE_PM_ACTION_LPM_SEQUENCE | TRACE_PM_ACTION_FAIL) << TRACE_DEBUG_ACTION_SHIFT)  \
+								| (((uint32_t)step) << TRACE_PM_ACTION_LPM_SEQ_SHIFT)		     \
+								| (0U))
+	#else
+		#define lpm_seq_trace_fail(step)
+	#endif
 #else
 	#define lpm_seq_trace(step)
 	#define lpm_seq_trace_fail(step)


### PR DESCRIPTION
Cleanup the lpm sequence to:
1. Update the trace numbers
2. Remove unwanted traces
3. Add return value checks to functions
4. Print the lpm traces conditionally

Logs: Tested Deep sleep and RTC plus DDR by building ATF with LOG_LEVEL_INFO and without that
[am62l_lpm_traces.txt](https://github.com/user-attachments/files/23209669/am62l_lpm_traces.txt)
