### PR TITLE
Add firewall configurations in AM62L SoC init

### DIFF
--- a/plat/ti/k3/board/am62l/soc.c
+++ b/plat/ti/k3/board/am62l/soc.c
@@ -13,6 +13,26 @@
 #include <ti_sci.h>
 #include <ti_sci_transport.h>
 
+#define TFA_HOST_ID		10U
+#define A53_PRIV_ID		4U
+#define FW_ENABLE_REGION        0x0a
+#define FW_CACHE_MODE		BIT(9)
+#define FW_WILDCARD_PRIVID      0xc3
+#define FW_NON_SECURE           GENMASK_32(15, 0)
+
+static struct fwl_data {
+	uint16_t fwl_id;
+	uint16_t fwl_region;
+	uint64_t start_address;
+	uint64_t end_address;
+} const fwls[] = {
+	{1, 1, 0x80a00000, 0x100000000},	/* DDR. Start addr is BL32 base + sizeof(OP-TEE), */
+						/* end addr is +2GB from start of DDR */
+	{97, 2, 0x500000000, 0x5ffffffff},	/* OSPI */
+	{160, 1, 0x28001000, 0x280013ff},	/* ADC */
+	{160, 2, 0x02b00000, 0x02b01fff},	/* MCASP */
+};
+
 /* Table of regions to map using the MMU */
 /* TODO: Add AM62L specific mapping such that K3 devices don't break */
 const mmap_region_t plat_k3_mmap[] = {
@@ -23,6 +43,37 @@ const mmap_region_t plat_k3_mmap[] = {
 #endif
 	{ /* sentinel */ }
 };
+
+void update_fwl_configs(struct fwl_data fwl)
+{
+	int ret;
+	uint8_t owner_index = TFA_HOST_ID;
+	uint8_t owner_privid = A53_PRIV_ID;
+	uint16_t owner_permission_bits = 0xffff;
+	uint32_t control = 0;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
+
+	ret = ti_sci_change_fwl_owner(fwl.fwl_id, fwl.fwl_region, owner_index,
+					&owner_privid, &owner_permission_bits);
+	if (ret) {
+		ERROR("Could not change firewall owner (%d)\n", ret);
+		return;
+	}
+
+	permissions[0] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+	permissions[1] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+	permissions[2] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+	control = (FW_CACHE_MODE | FW_ENABLE_REGION);
+
+	ret = ti_sci_set_fwl_region(fwl.fwl_id, fwl.fwl_region, 3,
+				    control, permissions,
+				    fwl.start_address, fwl.end_address);
+	if (ret) {
+		ERROR("Could not set firewall region information (%d)\n", ret);
+		return;
+	}
+
+}
 
 int ti_soc_init(void)
 {
@@ -62,6 +113,10 @@ int ti_soc_init(void)
 		ERROR("Unable to set boot control (%d)\n", ret);
 		return ret;
 	}
+
+	/* Update firewall configurations */
+	for (int i = 0; i < ARRAY_SIZE(fwls); i++)
+		update_fwl_configs(fwls[i]);
 
 	return 0;
 }

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci.c
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -1827,6 +1828,178 @@ int ti_sci_prepare_sleep(uint8_t mode, uint64_t context_save_addr,
 		ERROR("Transfer send failed (%d)\n", ret);
 		return ret;
 	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_set_fwl_region - Request for configuring a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to set
+ * @control:            Contents of the firewall CONTROL register to set
+ * @permissions:        Contents of the firewall PERMISSION register to set
+ * @start_address:      Contents of the firewall START_ADDRESS register to set
+ * @end_address:        Contents of the firewall END_ADDRESS register to set
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t start_address, uint64_t end_address)
+{
+	struct ti_sci_msg_req_fwl_set_firewall_region req = { };
+	struct ti_sci_msg_resp_fwl_set_firewall_region resp = { };
+	struct ti_sci_xfer xfer = { };
+	unsigned int i;
+	int ret;
+
+	assert(n_permission_regs <= FWL_MAX_PRIVID_SLOTS);
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_SET, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.n_permission_regs = n_permission_regs;
+	req.control = control;
+	for (i = 0; i < n_permission_regs; i++)
+		req.permissions[i] = permissions[i];
+	req.start_address = start_address;
+	req.end_address = end_address;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_get_fwl_region - Request for getting a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Region or channel number to set config info
+ * @control:            Contents of the firewall CONTROL register
+ * @permissions:        Contents of the firewall PERMISSION register
+ * @start_address:      Contents of the firewall START_ADDRESS register
+ * @end_address:        Contents of the firewall END_ADDRESS register
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t *start_address, uint64_t *end_address)
+{
+	struct ti_sci_msg_req_fwl_get_firewall_region req = { };
+	struct ti_sci_msg_resp_fwl_get_firewall_region resp = { };
+	struct ti_sci_xfer xfer = { };
+	unsigned int i;
+	int ret;
+
+	assert(n_permission_regs <= FWL_MAX_PRIVID_SLOTS);
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_GET, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.n_permission_regs = n_permission_regs;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*control = resp.control;
+	for (i = 0; i < n_permission_regs; i++)
+		permissions[i] = resp.permissions[i];
+	*start_address = resp.start_address;
+	*end_address = resp.end_address;
+
+	return 0;
+}
+
+/**
+ * ti_sci_change_fwl_owner() - Request for changing a firewall owner
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @owner_index:        New owner index to transfer ownership to
+ * @owner_privid:       New owner priv-ID returned by DMSC. This field is
+ *                      currently initialized to zero by DMSC.
+ * @owner_permission_bits: New owner permission bits returned by DMSC. This
+ *                         field is currently initialized to zero by DMSC.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits)
+{
+	struct ti_sci_msg_req_fwl_change_owner_info req = { };
+	struct ti_sci_msg_resp_fwl_change_owner_info resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_CHANGE_OWNER, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.owner_index = owner_index;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*owner_privid = resp.owner_privid;
+	*owner_permission_bits = resp.owner_permission_bits;
 
 	return 0;
 }

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci.h
@@ -13,6 +13,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "ti_sci_protocol.h"
+
 /**
  * User exported structures.
  *
@@ -277,6 +279,74 @@ int ti_sci_lpm_get_next_sys_mode(uint8_t *next_mode);
  */
 int ti_sci_prepare_sleep(uint8_t mode, uint64_t context_save_addr,
 			 uint32_t debug_flags);
+/**
+ * ti_sci_set_fwl_region() - Request for configuring a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to set
+ * @control:            Contents of the firewall CONTROL register to set
+ * @permissions:        Contents of the firewall PERMISSION register to set
+ * @start_address:      Contents of the firewall START_ADDRESS register to set
+ * @end_address:        Contents of the firewall END_ADDRESS register to set
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t start_address, uint64_t end_address);
+/**
+ * ti_sci_cmd_get_fwl_region() - Request for getting a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Region or channel number to set config info
+ * @control:            Contents of the firewall CONTROL register
+ * @permissions:        Contents of the firewall PERMISSION register
+ * @start_address:      Contents of the firewall START_ADDRESS register
+ * @end_address:        Contents of the firewall END_ADDRESS register
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t *start_address, uint64_t *end_address);
+/**
+ * ti_sci_change_fwl_owner() - Request for changing a firewall owner
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @owner_index:        New owner index to transfer ownership to
+ * @owner_privid:       New owner priv-ID returned by DMSC. This field is
+ *                      currently initialized to zero by DMSC.
+ * @owner_permission_bits: New owner permission bits returned by DMSC. This
+ *                         field is currently initialized to zero by DMSC.
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits);
 
 /**
  * Keywriter Lite Operations

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci_protocol.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci_protocol.h
@@ -13,6 +13,7 @@
 #ifndef TI_SCI_PROTOCOL_H
 #define TI_SCI_PROTOCOL_H
 
+#include <cdefs.h>
 #include <stdint.h>
 
 /* Generic Messages */
@@ -53,6 +54,11 @@
 #define TISCI_MSG_PROC_AUTH_BOOT_IMAGE	0xc120
 #define TISCI_MSG_GET_PROC_BOOT_STATUS	0xc400
 #define TISCI_MSG_WAIT_PROC_BOOT_STATUS	0xc401
+
+/* Security Management Messages */
+#define TI_SCI_MSG_FWL_SET               0x9000
+#define TI_SCI_MSG_FWL_GET               0x9001
+#define TI_SCI_MSG_FWL_CHANGE_OWNER      0x9002
 
 /* OTP MMR messages */
 #define TISCI_MSG_READ_OTP_MMR		0x9022
@@ -856,6 +862,128 @@ struct tisci_msg_min_context_restore_req {
 	struct ti_sci_msg_hdr	hdr;
 	uint32_t			ctx_lo;
 	uint32_t			ctx_hi;
+} __packed;
+
+#define FWL_MAX_PRIVID_SLOTS			3U
+
+/**
+ * struct ti_sci_msg_req_fwl_set_firewall_region - Set firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to set
+ * @control:		Contents of the firewall CONTROL register to set
+ * @permissions:	Contents of the firewall PERMISSION register to set
+ * @start_address:	Contents of the firewall START_ADDRESS register to set
+ * @end_address:	Contents of the firewall END_ADDRESS register to set
+ */
+struct ti_sci_msg_req_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+struct ti_sci_msg_resp_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_get_firewall_region - Retrieve firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to retrieve
+ */
+struct ti_sci_msg_req_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_get_firewall_region - Response for retrieving the
+ *						    firewall permissions
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers retrieved
+ * @control:		Contents of the firewall CONTROL register
+ * @permissions:	Contents of the firewall PERMISSION registers
+ * @start_address:	Contents of the firewall START_ADDRESS register
+ * @end_address:	Contents of the firewall END_ADDRESS register
+ */
+struct ti_sci_msg_resp_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_change_owner_info - Request change firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number if applicable
+ * @owner_index:	New owner index to transfer ownership to
+ */
+struct ti_sci_msg_req_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_change_owner_info - Response for change
+ *						  firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID specified in request
+ * @region:		Region or channel number specified in request
+ * @owner_index:	Owner index specified in request
+ * @owner_privid:	New owner priv-ID returned by DMSC.
+ * @owner_permission_bits:	New owner permission bits returned by DMSC.
+ */
+struct ti_sci_msg_resp_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+	uint8_t owner_privid;
+	uint16_t owner_permission_bits;
 } __packed;
 
 /**


### PR DESCRIPTION
PR summary below, generated using Co-pilot:

---

This pull request adds support for configuring and managing firewall regions via the TI SCI interface, specifically for the AM62L platform. It introduces new data structures, protocol message definitions, and helper functions to set up, retrieve, and change ownership of firewall regions during SoC initialization.

Key changes include:

**Firewall Region Management API:**

* Introduced new TI SCI protocol message IDs and corresponding request/response structures for setting, getting, and changing ownership of firewall regions in `ti_sci_protocol.h`. [[1]](diffhunk://#diff-ef287ecbc893e721065d7acc049e32200fbefe61a59329a4dae6ca96d028476aR57-R61) [[2]](diffhunk://#diff-ef287ecbc893e721065d7acc049e32200fbefe61a59329a4dae6ca96d028476aR866-R987)
* Added new API functions to `ti_sci.h` and their implementations in `ti_sci.c` for `ti_sci_set_fwl_region`, `ti_sci_get_fwl_region`, and `ti_sci_change_fwl_owner`, enabling programmatic control over firewall regions. [[1]](diffhunk://#diff-2396e2520fd92487d9f91f1a058ef82d1e452b36cd9e223f103351a53f81bd7eR283-R350) [[2]](diffhunk://#diff-ce59f501fb72eec916ebbfc8bd7f8f4c714ceb1abe1861fe43e87a99fa3f8a29R1834-R2005)

**AM62L Platform Integration:**

* Defined a static table of firewall regions (`fwls`) and added logic in `soc.c` to update firewall configurations during SoC initialization, using the new API to set up DDR, OSPI, ADC, and MCASP regions. [[1]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R16-R32) [[2]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R44-R74) [[3]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R114-R117)

**General Improvements:**

* Included necessary header and macro definitions to support the new firewall management features, such as `assert.h` and protocol constants. [[1]](diffhunk://#diff-2396e2520fd92487d9f91f1a058ef82d1e452b36cd9e223f103351a53f81bd7eR15-R17) [[2]](diffhunk://#diff-ef287ecbc893e721065d7acc049e32200fbefe61a59329a4dae6ca96d028476aR57-R61)