### PR TITLE
Add firewall configurations in AM62L SoC init for HS-SE devices

### DIFF
--- a/plat/ti/k3/board/am62l/soc.c
+++ b/plat/ti/k3/board/am62l/soc.c
@@ -13,6 +13,26 @@
 #include <ti_sci.h>
 #include <ti_sci_transport.h>
 
+#define TFA_HOST_ID		10U
+#define A53_PRIV_ID		4U
+#define FW_ENABLE_REGION        0x0a
+#define FW_CACHE_MODE		BIT(9)
+#define FW_WILDCARD_PRIVID      0xc3
+#define FW_NON_SECURE           GENMASK_32(15, 0)
+
+static struct fwl_data {
+	uint16_t fwl_id;
+	uint16_t fwl_region;
+	uint64_t start_address;
+	uint64_t end_address;
+} const fwls[] = {
+	{1, 1, 0x80a00000, 0x100000000},	/* DDR. Start addr is BL32 base + sizeof(OP-TEE), */
+						/* end addr is +2GB from start of DDR */
+	{97, 2, 0x500000000, 0x5ffffffff},	/* OSPI */
+	{160, 1, 0x28001000, 0x280013ff},	/* ADC */
+	{160, 2, 0x02b00000, 0x02b01fff},	/* MCASP */
+};
+
 /* Table of regions to map using the MMU */
 /* TODO: Add AM62L specific mapping such that K3 devices don't break */
 const mmap_region_t plat_k3_mmap[] = {
@@ -23,6 +43,66 @@ const mmap_region_t plat_k3_mmap[] = {
 #endif
 	{ /* sentinel */ }
 };
+
+void update_fwl_configs(struct fwl_data fwl)
+{
+	int ret;
+	uint8_t owner_index = TFA_HOST_ID;
+	uint8_t owner_privid = A53_PRIV_ID;
+	uint16_t owner_permission_bits = 0xffff;
+	uint32_t control = 0;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
+
+	ret = ti_sci_change_fwl_owner(fwl.fwl_id, fwl.fwl_region, owner_index,
+					&owner_privid, &owner_permission_bits);
+	if (ret) {
+		ERROR("Could not change firewall owner (%d)\n", ret);
+		panic();
+	}
+
+	permissions[0] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+	permissions[1] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+	permissions[2] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+	control = (FW_CACHE_MODE | FW_ENABLE_REGION);
+
+	ret = ti_sci_set_fwl_region(fwl.fwl_id, fwl.fwl_region, 3,
+				    control, permissions,
+				    fwl.start_address, fwl.end_address);
+	if (ret) {
+		ERROR("Could not set firewall region information (%d)\n", ret);
+		panic();
+	}
+
+}
+
+static enum k3_device_type get_device_type(void)
+{
+	uint32_t sys_status = mmio_read_32(K3_SEC_MGR_SYS_STATUS);
+
+	uint32_t sys_dev_type = (sys_status & SYS_STATUS_DEV_TYPE_MASK) >>
+			SYS_STATUS_DEV_TYPE_SHIFT;
+
+	uint32_t sys_sub_type = (sys_status & SYS_STATUS_SUB_TYPE_MASK) >>
+			SYS_STATUS_SUB_TYPE_SHIFT;
+
+	printf("%s %x\n", __func__, sys_status);
+
+	switch (sys_dev_type) {
+	case SYS_STATUS_DEV_TYPE_GP:
+		return K3_DEVICE_TYPE_GP;
+	case SYS_STATUS_DEV_TYPE_TEST:
+		return K3_DEVICE_TYPE_TEST;
+	case SYS_STATUS_DEV_TYPE_EMU:
+		return K3_DEVICE_TYPE_EMU;
+	case SYS_STATUS_DEV_TYPE_HS:
+		if (sys_sub_type == SYS_STATUS_SUB_TYPE_VAL_FS)
+			return K3_DEVICE_TYPE_HS_FS;
+		else
+			return K3_DEVICE_TYPE_HS_SE;
+	default:
+		return K3_DEVICE_TYPE_BAD;
+	}
+}
 
 int ti_soc_init(void)
 {
@@ -61,6 +141,12 @@ int ti_soc_init(void)
 	if (ret) {
 		ERROR("Unable to set boot control (%d)\n", ret);
 		return ret;
+	}
+
+	if (get_device_type() == K3_DEVICE_TYPE_HS_SE) {
+		/* Update firewall configurations */
+		for (int i = 0; i < ARRAY_SIZE(fwls); i++)
+			update_fwl_configs(fwls[i]);
 	}
 
 	return 0;

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci.c
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -1827,6 +1828,178 @@ int ti_sci_prepare_sleep(uint8_t mode, uint64_t context_save_addr,
 		ERROR("Transfer send failed (%d)\n", ret);
 		return ret;
 	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_set_fwl_region - Request for configuring a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to set
+ * @control:            Contents of the firewall CONTROL register to set
+ * @permissions:        Contents of the firewall PERMISSION register to set
+ * @start_address:      Contents of the firewall START_ADDRESS register to set
+ * @end_address:        Contents of the firewall END_ADDRESS register to set
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t start_address, uint64_t end_address)
+{
+	struct ti_sci_msg_req_fwl_set_firewall_region req = { };
+	struct ti_sci_msg_resp_fwl_set_firewall_region resp = { };
+	struct ti_sci_xfer xfer = { };
+	unsigned int i;
+	int ret;
+
+	assert(n_permission_regs <= FWL_MAX_PRIVID_SLOTS);
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_SET, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.n_permission_regs = n_permission_regs;
+	req.control = control;
+	for (i = 0; i < n_permission_regs; i++)
+		req.permissions[i] = permissions[i];
+	req.start_address = start_address;
+	req.end_address = end_address;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_get_fwl_region - Request for getting a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Region or channel number to set config info
+ * @control:            Contents of the firewall CONTROL register
+ * @permissions:        Contents of the firewall PERMISSION register
+ * @start_address:      Contents of the firewall START_ADDRESS register
+ * @end_address:        Contents of the firewall END_ADDRESS register
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t *start_address, uint64_t *end_address)
+{
+	struct ti_sci_msg_req_fwl_get_firewall_region req = { };
+	struct ti_sci_msg_resp_fwl_get_firewall_region resp = { };
+	struct ti_sci_xfer xfer = { };
+	unsigned int i;
+	int ret;
+
+	assert(n_permission_regs <= FWL_MAX_PRIVID_SLOTS);
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_GET, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.n_permission_regs = n_permission_regs;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*control = resp.control;
+	for (i = 0; i < n_permission_regs; i++)
+		permissions[i] = resp.permissions[i];
+	*start_address = resp.start_address;
+	*end_address = resp.end_address;
+
+	return 0;
+}
+
+/**
+ * ti_sci_change_fwl_owner() - Request for changing a firewall owner
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @owner_index:        New owner index to transfer ownership to
+ * @owner_privid:       New owner priv-ID returned by DMSC. This field is
+ *                      currently initialized to zero by DMSC.
+ * @owner_permission_bits: New owner permission bits returned by DMSC. This
+ *                         field is currently initialized to zero by DMSC.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits)
+{
+	struct ti_sci_msg_req_fwl_change_owner_info req = { };
+	struct ti_sci_msg_resp_fwl_change_owner_info resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_CHANGE_OWNER, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.owner_index = owner_index;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*owner_privid = resp.owner_privid;
+	*owner_permission_bits = resp.owner_permission_bits;
 
 	return 0;
 }

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci.h
@@ -13,6 +13,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "ti_sci_protocol.h"
+
 /**
  * User exported structures.
  *
@@ -277,6 +279,74 @@ int ti_sci_lpm_get_next_sys_mode(uint8_t *next_mode);
  */
 int ti_sci_prepare_sleep(uint8_t mode, uint64_t context_save_addr,
 			 uint32_t debug_flags);
+/**
+ * ti_sci_set_fwl_region() - Request for configuring a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to set
+ * @control:            Contents of the firewall CONTROL register to set
+ * @permissions:        Contents of the firewall PERMISSION register to set
+ * @start_address:      Contents of the firewall START_ADDRESS register to set
+ * @end_address:        Contents of the firewall END_ADDRESS register to set
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t start_address, uint64_t end_address);
+/**
+ * ti_sci_cmd_get_fwl_region() - Request for getting a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Region or channel number to set config info
+ * @control:            Contents of the firewall CONTROL register
+ * @permissions:        Contents of the firewall PERMISSION register
+ * @start_address:      Contents of the firewall START_ADDRESS register
+ * @end_address:        Contents of the firewall END_ADDRESS register
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t *start_address, uint64_t *end_address);
+/**
+ * ti_sci_change_fwl_owner() - Request for changing a firewall owner
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @owner_index:        New owner index to transfer ownership to
+ * @owner_privid:       New owner priv-ID returned by DMSC. This field is
+ *                      currently initialized to zero by DMSC.
+ * @owner_permission_bits: New owner permission bits returned by DMSC. This
+ *                         field is currently initialized to zero by DMSC.
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits);
 
 /**
  * Keywriter Lite Operations

--- a/plat/ti/k3/common/drivers/ti_sci/ti_sci_protocol.h
+++ b/plat/ti/k3/common/drivers/ti_sci/ti_sci_protocol.h
@@ -13,6 +13,7 @@
 #ifndef TI_SCI_PROTOCOL_H
 #define TI_SCI_PROTOCOL_H
 
+#include <cdefs.h>
 #include <stdint.h>
 
 /* Generic Messages */
@@ -53,6 +54,11 @@
 #define TISCI_MSG_PROC_AUTH_BOOT_IMAGE	0xc120
 #define TISCI_MSG_GET_PROC_BOOT_STATUS	0xc400
 #define TISCI_MSG_WAIT_PROC_BOOT_STATUS	0xc401
+
+/* Security Management Messages */
+#define TI_SCI_MSG_FWL_SET               0x9000
+#define TI_SCI_MSG_FWL_GET               0x9001
+#define TI_SCI_MSG_FWL_CHANGE_OWNER      0x9002
 
 /* OTP MMR messages */
 #define TISCI_MSG_READ_OTP_MMR		0x9022
@@ -856,6 +862,128 @@ struct tisci_msg_min_context_restore_req {
 	struct ti_sci_msg_hdr	hdr;
 	uint32_t			ctx_lo;
 	uint32_t			ctx_hi;
+} __packed;
+
+#define FWL_MAX_PRIVID_SLOTS			3U
+
+/**
+ * struct ti_sci_msg_req_fwl_set_firewall_region - Set firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to set
+ * @control:		Contents of the firewall CONTROL register to set
+ * @permissions:	Contents of the firewall PERMISSION register to set
+ * @start_address:	Contents of the firewall START_ADDRESS register to set
+ * @end_address:	Contents of the firewall END_ADDRESS register to set
+ */
+struct ti_sci_msg_req_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+struct ti_sci_msg_resp_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_get_firewall_region - Retrieve firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to retrieve
+ */
+struct ti_sci_msg_req_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_get_firewall_region - Response for retrieving the
+ *						    firewall permissions
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers retrieved
+ * @control:		Contents of the firewall CONTROL register
+ * @permissions:	Contents of the firewall PERMISSION registers
+ * @start_address:	Contents of the firewall START_ADDRESS register
+ * @end_address:	Contents of the firewall END_ADDRESS register
+ */
+struct ti_sci_msg_resp_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_change_owner_info - Request change firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number if applicable
+ * @owner_index:	New owner index to transfer ownership to
+ */
+struct ti_sci_msg_req_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_change_owner_info - Response for change
+ *						  firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID specified in request
+ * @region:		Region or channel number specified in request
+ * @owner_index:	Owner index specified in request
+ * @owner_privid:	New owner priv-ID returned by DMSC.
+ * @owner_permission_bits:	New owner permission bits returned by DMSC.
+ */
+struct ti_sci_msg_resp_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+	uint8_t owner_privid;
+	uint16_t owner_permission_bits;
 } __packed;
 
 /**

--- a/plat/ti/k3/include/plat_private.h
+++ b/plat/ti/k3/include/plat_private.h
@@ -19,6 +19,26 @@
 
 extern const mmap_region_t plat_k3_mmap[];
 
+enum k3_device_type {
+	K3_DEVICE_TYPE_BAD,
+	K3_DEVICE_TYPE_GP,
+	K3_DEVICE_TYPE_TEST,
+	K3_DEVICE_TYPE_EMU,
+	K3_DEVICE_TYPE_HS_FS,
+	K3_DEVICE_TYPE_HS_SE,
+};
+
+#define K3_SEC_MGR_SYS_STATUS		0x44234100
+#define SYS_STATUS_DEV_TYPE_SHIFT	0
+#define SYS_STATUS_DEV_TYPE_MASK	(0xf)
+#define SYS_STATUS_DEV_TYPE_GP		0x3
+#define SYS_STATUS_DEV_TYPE_TEST	0x5
+#define SYS_STATUS_DEV_TYPE_EMU		0x9
+#define SYS_STATUS_DEV_TYPE_HS		0xa
+#define SYS_STATUS_SUB_TYPE_SHIFT	8
+#define SYS_STATUS_SUB_TYPE_MASK	(0xf << 8)
+#define SYS_STATUS_SUB_TYPE_VAL_FS	0xa
+
 void ti_init_scmi_server(void);
 
 /* Any kind of SOC specific init can be done here */


### PR DESCRIPTION
PR summary below, generated using Co-pilot:
---

This pull request adds support for configuring firewall regions on the AM62L platform, specifically for High Security Secure Enclave (HS-SE) devices. It introduces new TI SCI protocol messages, structures, and helper functions to manage firewall ownership and permissions, and updates the SoC initialization flow to configure firewalls as needed.

**Firewall configuration support for AM62L HS-SE devices:**

* **New TI SCI protocol messages and structures for firewall management:**  
  Added message IDs (`TI_SCI_MSG_FWL_SET`, `TI_SCI_MSG_FWL_GET`, `TI_SCI_MSG_FWL_CHANGE_OWNER`) and corresponding request/response structures to `ti_sci_protocol.h` for setting, getting, and changing firewall region ownership. [[1]](diffhunk://#diff-ef287ecbc893e721065d7acc049e32200fbefe61a59329a4dae6ca96d028476aR58-R62) [[2]](diffhunk://#diff-ef287ecbc893e721065d7acc049e32200fbefe61a59329a4dae6ca96d028476aR867-R988)

* **Helper functions for firewall operations:**  
  Implemented `ti_sci_set_fwl_region`, `ti_sci_get_fwl_region`, and `ti_sci_change_fwl_owner` in `ti_sci.c`, with corresponding declarations and documentation in `ti_sci.h`. These enable setting permissions, retrieving region info, and transferring region ownership. [[1]](diffhunk://#diff-ce59f501fb72eec916ebbfc8bd7f8f4c714ceb1abe1861fe43e87a99fa3f8a29R1835-R2006) [[2]](diffhunk://#diff-2396e2520fd92487d9f91f1a058ef82d1e452b36cd9e223f103351a53f81bd7eR282-R349)

* **Platform-specific firewall configuration logic:**  
  Defined a static array of firewall regions (`fwls`) and a function `update_fwl_configs` in `am62l/soc.c` to set up ownership and permissions for each region. The SoC initialization (`ti_soc_init`) now configures firewalls if the device type is HS-SE, using the new helper functions. [[1]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R16-R35) [[2]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R47-R106) [[3]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R146-R151)

**Device type detection and constants:**

* **Device type enumeration and detection:**  
  Added `enum k3_device_type` and related constants/macros to `plat_private.h`, along with a function to read and decode the device type from hardware registers. This enables conditional firewall configuration based on device security state. [[1]](diffhunk://#diff-1bb86a58ed58d60ec2a841e46241b6ac84ac72c88285bf681b4a1185fc100f79R22-R41) [[2]](diffhunk://#diff-95e0aa11c2b679882418275e944c295aab7b764fab7f3d46da6594f190858f10R47-R106)

**Minor improvements:**

* **Code hygiene:**  
  Included missing headers (`assert.h` in `ti_sci.c`, `ti_sci_protocol.h` in `ti_sci.h`) for robustness and clarity. [[1]](diffhunk://#diff-ce59f501fb72eec916ebbfc8bd7f8f4c714ceb1abe1861fe43e87a99fa3f8a29R10) [[2]](diffhunk://#diff-2396e2520fd92487d9f91f1a058ef82d1e452b36cd9e223f103351a53f81bd7eR16-R17)