### PR TITLE
Lpm resume fix

### DIFF
--- a/plat/ti/k3/board/am62l-badge/board.mk
+++ b/plat/ti/k3/board/am62l-badge/board.mk
@@ -72,7 +72,8 @@ PLAT_INCLUDES		+=	\
 				-Iinclude/lib/libfdt	\
 				-I${PLAT_PATH}/board/am62l/include	\
 				-I${PLAT_PATH}/board/am62l/pm	\
-				-I${PLAT_PATH}/board/am62l/scmi
+				-I${PLAT_PATH}/board/am62l/scmi	\
+				-I${PLAT_PATH}/board/am62l/fwl
 
 K3_LPDDR4_SOURCES	+= 	\
 				${PLAT_PATH}/common/drivers/lpddr4/k3-ddrss.c \
@@ -111,3 +112,4 @@ BL31_SOURCES		+=	\
 				drivers/scmi-msg/smt.c			\
 				drivers/scmi-msg/clock.c			\
 				drivers/scmi-msg/power_domain.c		\
+				${PLAT_PATH}/board/am62l/fwl/fwl.c

--- a/plat/ti/k3/board/am62l/board.mk
+++ b/plat/ti/k3/board/am62l/board.mk
@@ -103,6 +103,7 @@ include ${PLAT_PATH}/board/am62l/lpm/lpm.mk
 
 PLAT_INCLUDES += -Iplat/ti/k3/board/${TARGET_BOARD}/pm			\
 		 -I${PLAT_PATH}/board/am62l/scmi			\
+		 -I${PLAT_PATH}/board/am62l/fwl			\
 
 BL31_SOURCES		+=	\
 				${PLAT_PATH}/common/k3_svc.c		\
@@ -112,3 +113,4 @@ BL31_SOURCES		+=	\
 				drivers/scmi-msg/smt.c			\
 				drivers/scmi-msg/clock.c			\
 				drivers/scmi-msg/power_domain.c		\
+				${PLAT_PATH}/board/am62l/fwl/fwl.c

--- a/plat/ti/k3/board/am62l/fwl/fwl.c
+++ b/plat/ti/k3/board/am62l/fwl/fwl.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Texas Instruments Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <common/debug.h>
+#include <fwl.h>
+#include <ti_sci.h>
+
+const struct fwl_data fwls[] = {
+	{DDR_FWL_ID, DDR_FWL_NUM_REGIONS},	/* DDR */
+	{OSPI_FWL_ID, OSPI_FWL_NUM_REGIONS},	/* OSPI */
+	{ADC_MCASP_FWL_ID, ADC_MCASP_FWL_NUM_REGIONS},	/* ADC and MCASP */
+};
+
+const size_t fwls_count = ARRAY_SIZE(fwls);
+
+/*
+ * Removes firewall configurations for a given firewall and region type.
+ * This function iterates through all regions of the specified firewall,
+ * takes ownership, reads the current configuration, and disables any
+ * active firewall regions of the requested type (foreground or background).
+ *
+ * @fwl: Firewall data containing the firewall ID and number of regions
+ * @fwl_type: Type of firewall region to remove (foreground or background)
+ */
+static void remove_fwl_configs(struct fwl_data fwl, enum k3_fwl_region_type fwl_type)
+{
+	uint8_t owner_index = TFA_HOST_ID;
+	uint8_t owner_privid = A53_PRIV_ID;
+	uint16_t owner_permission_bits = 0;
+	uint32_t control = 0;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
+	uint32_t n_permission_regs = FWL_MAX_PRIVID_SLOTS;
+	uint64_t start_address = 0;
+	uint64_t end_address = 0;
+	int ret = 0;
+
+	for (int i = 0; i < fwl.num_regions; i++) {
+		ret = ti_sci_change_fwl_owner(fwl.fwl_id, i, owner_index,
+				&owner_privid, &owner_permission_bits);
+		if (ret) {
+			ERROR("Could not change firewall owner (%d)\n", ret);
+			continue;
+		}
+
+		ret = ti_sci_get_fwl_region(fwl.fwl_id, i, n_permission_regs,
+			&control, permissions, &start_address, &end_address);
+		if (ret) {
+			ERROR("Could not get firewall region information (%d)\n", ret);
+			continue;
+		}
+
+		if (control != 0 && (control & (1 << FW_BACKGROUND_BIT)) == fwl_type) {
+			control = 0;
+
+			ret = ti_sci_set_fwl_region(fwl.fwl_id, i, n_permission_regs,
+				control, permissions, start_address, end_address);
+			if (ret) {
+				ERROR("Could not disable firewall region information (%d)\n", ret);
+				panic();
+			}
+		}
+	}
+}
+
+void update_fwl_configs(void)
+{
+	/* Disable firewalls that were configured by ROM for boot phase */
+	for (int i = 0; i < fwls_count; i++) {
+		remove_fwl_configs(fwls[i], K3_FWL_REGION_FOREGROUND);
+		remove_fwl_configs(fwls[i], K3_FWL_REGION_BACKGROUND);
+	}
+}

--- a/plat/ti/k3/board/am62l/fwl/fwl.h
+++ b/plat/ti/k3/board/am62l/fwl/fwl.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, Texas Instruments Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWL_H
+#define FWL_H
+
+#include <stdint.h>
+#include <lib/utils_def.h>
+
+#define TFA_HOST_ID		10U
+#define A53_PRIV_ID		4U
+#define FW_BACKGROUND_BIT	8U
+
+/* Firewall IDs */
+#define DDR_FWL_ID		1U
+#define OSPI_FWL_ID		97U
+#define ADC_MCASP_FWL_ID	160U
+
+/* Number of firewall regions */
+#define DDR_FWL_NUM_REGIONS		16U
+#define OSPI_FWL_NUM_REGIONS		8U
+#define ADC_MCASP_FWL_NUM_REGIONS	16U
+
+enum k3_fwl_region_type {
+	K3_FWL_REGION_FOREGROUND = 0,
+	K3_FWL_REGION_BACKGROUND = BIT(FW_BACKGROUND_BIT),
+};
+
+struct fwl_data {
+	uint16_t fwl_id;
+	uint8_t num_regions;
+};
+
+/*
+ * Updates firewall configurations by disabling ROM-configured firewalls.
+ * This function should be called during boot initialization and after
+ * resume from low power mode to ensure firewall regions that were
+ * configured by ROM for the boot phase are properly disabled.
+ */
+void update_fwl_configs(void);
+
+#endif /* FWL_H */

--- a/plat/ti/k3/board/am62l/soc.c
+++ b/plat/ti/k3/board/am62l/soc.c
@@ -6,40 +6,13 @@
 
 #include <common/debug.h>
 #include <device_wrapper.h>
+#include <fwl.h>
 #include <lpm_stub.h>
 #include <plat_private.h>
 #include <plat_scmi_def.h>
 #include <rtc.h>
 #include <ti_sci.h>
 #include <ti_sci_transport.h>
-
-#define TFA_HOST_ID		10U
-#define A53_PRIV_ID		4U
-#define FW_BACKGROUND_BIT	8U
-
-/* Firewall IDs */
-#define DDR_FWL_ID		1U
-#define OSPI_FWL_ID		97U
-#define ADC_MCASP_FWL_ID	160U
-
-/* Number of firewall regions */
-#define DDR_FWL_NUM_REGIONS		16U
-#define OSPI_FWL_NUM_REGIONS		8U
-#define ADC_MCASP_FWL_NUM_REGIONS 	16U
-
-enum k3_fwl_region_type {
-	K3_FWL_REGION_FOREGROUND = 0,
-	K3_FWL_REGION_BACKGROUND = BIT(FW_BACKGROUND_BIT),
-};
-
-static struct fwl_data {
-	uint16_t fwl_id;
-	uint8_t num_regions;
-} const fwls[] = {
-	{DDR_FWL_ID, DDR_FWL_NUM_REGIONS},	/* DDR */
-	{OSPI_FWL_ID, OSPI_FWL_NUM_REGIONS},	/* OSPI */
-	{ADC_MCASP_FWL_ID, ADC_MCASP_FWL_NUM_REGIONS},	/* ADC and MCASP */
-};
 
 /* Table of regions to map using the MMU */
 /* TODO: Add AM62L specific mapping such that K3 devices don't break */
@@ -51,48 +24,6 @@ const mmap_region_t plat_k3_mmap[] = {
 #endif
 	{ /* sentinel */ }
 };
-
-void remove_fwl_configs(struct fwl_data fwl, enum k3_fwl_region_type fwl_type)
-{
-	uint8_t owner_index = TFA_HOST_ID;
-	uint8_t owner_privid = A53_PRIV_ID;
-	uint16_t owner_permission_bits = 0;
-	uint32_t control = 0;
-	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
-	uint32_t n_permission_regs = FWL_MAX_PRIVID_SLOTS;
-	uint64_t start_address = 0;
-	uint64_t end_address = 0;
-	int ret = 0;
-
-	for (int i = 0; i < fwl.num_regions; i++) {
-		ret = ti_sci_change_fwl_owner(fwl.fwl_id, i, owner_index,
-					      &owner_privid, &owner_permission_bits);
-		if (ret) {
-			ERROR("Could not change firewall owner (%d)\n", ret);
-			continue;
-		}
-
-		ret = ti_sci_get_fwl_region(fwl.fwl_id, i, n_permission_regs,
-					    &control, permissions,
-					    &start_address, &end_address);
-		if (ret) {
-			ERROR("Could not get firewall region information (%d)\n", ret);
-			continue;
-		}
-
-		if (control != 0 && (control & (1 << FW_BACKGROUND_BIT)) == fwl_type) {
-			control = 0;
-
-			ret = ti_sci_set_fwl_region(fwl.fwl_id, i, n_permission_regs,
-						    control, permissions,
-						    start_address, end_address);
-			if (ret) {
-				ERROR("Could not disable firewall region information (%d)\n", ret);
-				panic();
-			}
-		}
-	}
-}
 
 int ti_soc_init(void)
 {
@@ -134,10 +65,7 @@ int ti_soc_init(void)
 	}
 
 	/* Update firewall configurations */
-	for (int i = 0; i < ARRAY_SIZE(fwls); i++) {
-		remove_fwl_configs(fwls[i], K3_FWL_REGION_FOREGROUND);
-		remove_fwl_configs(fwls[i], K3_FWL_REGION_BACKGROUND);
-	}
+	update_fwl_configs();
 
 	return 0;
 }

--- a/plat/ti/k3/common/am62l_psci.c
+++ b/plat/ti/k3/common/am62l_psci.c
@@ -12,6 +12,7 @@
 #include <devices.h>
 #include <device.h>
 #include <drivers/arm/gicv3.h>
+#include <fwl.h>
 #include <gtc.h>
 #include <k3_console.h>
 #include <k3_gicv3.h>
@@ -343,6 +344,9 @@ static void am62l_pwr_domain_suspend(const psci_power_state_t *target_state)
 
 static void am62l_pwr_domain_suspend_finish(const psci_power_state_t *target_state)
 {
+	/* Disable ROM configured firewalls during resume */
+	update_fwl_configs();
+
 	/* Remove the I/O isolation */
 	k3_lpm_set_io_isolation(false);
 	/* Initialize the console to provide early debug support */


### PR DESCRIPTION
RTC + DDR low power mode resume is failing on HS-SE device. In order to fix that, reapply the firewall configuration applied at boot in resume sequence as well.