### PR TITLE
PENDING: feat(ti): Add support to handle poweroff request for AM62L

### DIFF
--- a/plat/ti/k3/board/am62l/include/board_def.h
+++ b/plat/ti/k3/board/am62l/include/board_def.h
@@ -35,6 +35,7 @@
 #define K3_GTC_CFG0_BASE		        (0xa80000UL)
 #define K3_GTC_CFG1_BASE		        (0xA90000UL)
 #define K3_RTC_BASE			        (0x2b1f0000UL)
+#define WKUP_CTRL_PMCTRL_SYS                    (0x80UL)
 
 /*******************************************************************************
  * Memory layout constants

--- a/plat/ti/k3/common/am62l_psci.c
+++ b/plat/ti/k3/common/am62l_psci.c
@@ -268,6 +268,25 @@ void am62l_pwr_domain_on_finish(const psci_power_state_t *target_state)
 	k3_gic_cpuif_enable();
 }
 
+static void __dead2 am62l_system_off(void)
+{
+	INFO("%s: Initiating system poweroff sequence\n", __func__);
+
+	/* Notify TIFS to prepare for poweroff (mode = 3 for RTC Only mode) */
+	ti_sci_prepare_sleep(0x3, 0, 0);
+
+	/* Enter poweroff by configuring PMIC control register */
+	mmio_write_32(WKUP_CTRL_MMR_SEC_5_BASE + WKUP_CTRL_PMCTRL_SYS, 0x0U);
+	dsb();
+	isb();
+
+	INFO("%s: PMIC control configured, waiting for poweroff\n", __func__);
+
+	/* Cannot safely recover - enter infinite WFI loop */
+	while (true)
+		wfi();
+}
+
 static void __dead2 am62l_system_reset(void)
 {
 	mmio_write_32(WKUP_CTRL_MMR0_DEVICE_MANAGEMENT_BASE + WKUP_CTRL_MMR0_DEVICE_RESET_OFFSET,
@@ -387,6 +406,7 @@ static plat_psci_ops_t am62l_plat_psci_ops = {
 	.pwr_domain_suspend_finish = am62l_pwr_domain_suspend_finish,
 	.get_sys_suspend_power_state = am62l_get_sys_suspend_power_state,
 #endif
+	.system_off = am62l_system_off,
 	.system_reset = am62l_system_reset,
 	.validate_power_state = k3_validate_power_state,
 };


### PR DESCRIPTION
Add support to shutdown the system for AM62L SoC when poweroff request is received from linux.
The SoC level control is used to power off the PMIC.

Change-Id: Ia379079a3e3a2b15e97aced3f7ca4c51072a5d89