### PR TITLE
Fix standby sequence and add Debugss LPSC

### DIFF
--- a/plat/ti/k3/board/am62l/lpm/standby.c
+++ b/plat/ti/k3/board/am62l/lpm/standby.c
@@ -97,7 +97,7 @@ void set_main_psc_state(uint32_t pd_id, uint32_t md_id, uint32_t pd_state, uint3
 	pdctrl = mmio_read_32(pdctrl_ptr);
 	pdstat = mmio_read_32(pdstat_ptr);
 
-	INFO("%s: before: md_id=%d, mdstat=0x%x, pdstat=0x%x\n", __func__, md_id, mdstat, pdstat);
+	VERBOSE("%s: before: md_id=%d, mdstat=0x%x, pdstat=0x%x\n", __func__, md_id, mdstat, pdstat);
 	if (((pdstat & 0x1) == pd_state) && ((mdstat & 0x1f) == md_state))
 		return;
 
@@ -149,7 +149,7 @@ void set_main_psc_state(uint32_t pd_id, uint32_t md_id, uint32_t pd_state, uint3
 	//check states
 	mdstat = mmio_read_32(mdstat_ptr);
 	pdstat = mmio_read_32(pdstat_ptr);
-	INFO("%s: after: md_id=%d, mdstat=0x%x, pdstat=0x%x\n", __func__, md_id, mdstat, pdstat);
+	VERBOSE("%s: after: md_id=%d, mdstat=0x%x, pdstat=0x%x\n", __func__, md_id, mdstat, pdstat);
 }
 
 void am62l_save_state()
@@ -176,6 +176,11 @@ void am62l_restore_state()
 {
     // AUTO CLOCK GATING OFF
     mmio_write_32(WKUP_CTRL_MMR_CFG5_CLKGATE_CTRL0,saved_state.auto_clk_gate);
+
+	//DDR out of AUTO SELF REFRESH
+	mmio_write_32(EMIF_CTLCFG_DENALI_CTL_168,saved_state.ddr_reg[0]);
+	mmio_write_32(EMIF_CTLCFG_DENALI_CTL_169,saved_state.ddr_reg[1]);
+	mmio_write_32(EMIF_CTLCFG_DENALI_CTL_167,saved_state.ddr_reg[2]);
 
     /* Restore PLL */
     for(int i=0;i<10;i++){

--- a/plat/ti/k3/board/am62l/lpm/standby.c
+++ b/plat/ti/k3/board/am62l/lpm/standby.c
@@ -178,8 +178,8 @@ void am62l_restore_state()
 
     // LPSC
     for(int i=0;i<LPSC_COUNT;i++){
-        if(saved_state.lpsc_value[lpsc_id[i]]!=0){
-        	set_main_psc_state(psc_id[i],lpsc_id[i],1,saved_state.lpsc_value[lpsc_id[i]]);
+        if(saved_state.lpsc_value[i]!=0){
+        	set_main_psc_state(psc_id[i],lpsc_id[i],PSC_PD_ON,saved_state.lpsc_value[i]);
         }
     }
 
@@ -205,8 +205,8 @@ void am62l_low_latency_standby()
 
 	// change the LPSC values only if they are not already disabled
 	for(int i=0;i<LPSC_COUNT;i++){
-		if(saved_state.lpsc_value[lpsc_id[i]]!=0){
-			set_main_psc_state(psc_id[i],lpsc_id[i],1,2);
+		if(saved_state.lpsc_value[i]!=0){
+			set_main_psc_state(psc_id[i],lpsc_id[i],PSC_PD_ON,PSC_DISABLE);
 		}
 	}
 

--- a/plat/ti/k3/board/am62l/lpm/standby.c
+++ b/plat/ti/k3/board/am62l/lpm/standby.c
@@ -42,16 +42,17 @@
 
 #define WKUP_CTRL_MMR_CFG5_CLKGATE_CTRL0 0x43054050
 
-#define LPSC_COUNT 4
+#define LPSC_COUNT 5
 
 static unsigned int lpsc_id[] = {
 	1,  /* LPSC_main_gp_test */
 	2,  /* LPSC_main_gp_pbist0 */
 	33, /* LPSC_mainip_pbist */
 	39, /* LPSC_main_mpu_clst0_pbist */
+	55, /* LPSC_debugss */
 };
 
-static unsigned int psc_id[] = {0,0,3,4};
+static unsigned int psc_id[] = {0,0,3,4,9};
 
 struct am62l_pm_state {
     uint32_t pll_hsdiv_val[11];
@@ -176,22 +177,30 @@ void am62l_restore_state()
     // AUTO CLOCK GATING OFF
     mmio_write_32(WKUP_CTRL_MMR_CFG5_CLKGATE_CTRL0,saved_state.auto_clk_gate);
 
+    /* Restore PLL */
+    for(int i=0;i<10;i++){
+        mmio_write_32(MAIN_PLL0_HSDIVx(i), saved_state.pll_hsdiv_val[i]);
+    }
+    mmio_write_32(MAIN_PLL8_CTRL,saved_state.pll_hsdiv_val[10]);
+
     // LPSC
     for(int i=0;i<LPSC_COUNT;i++){
         if(saved_state.lpsc_value[i]!=0){
         	set_main_psc_state(psc_id[i],lpsc_id[i],PSC_PD_ON,saved_state.lpsc_value[i]);
         }
     }
-
-    /* Restore PLL */
-    for(int i=0;i<10;i++){
-        mmio_write_32(MAIN_PLL0_HSDIVx(i), saved_state.pll_hsdiv_val[i]);
-    }
-    mmio_write_32(MAIN_PLL8_CTRL,saved_state.pll_hsdiv_val[10]);
 }
 
 void am62l_low_latency_standby()
 {
+
+	// change the LPSC values only if they are not already disabled
+	for(int i=0;i<LPSC_COUNT;i++){
+		if(saved_state.lpsc_value[i]!=0){
+			set_main_psc_state(psc_id[i],lpsc_id[i],PSC_PD_ON,PSC_DISABLE);
+		}
+	}
+
 	// MAIN_PLL0
 	mmio_write_32(MAIN_PLL0_HSDIVx(0), (saved_state.pll_hsdiv_val[0] & ~(0xff)) | 0xf);
 	mmio_write_32(MAIN_PLL0_HSDIVx(5), (saved_state.pll_hsdiv_val[5] & ~(0xff)) | 0x4);
@@ -202,13 +211,6 @@ void am62l_low_latency_standby()
 
 	// A53 running off Bypass clock
 	mmio_write_32(MAIN_PLL8_CTRL, saved_state.pll_hsdiv_val[10] | 0x80000000);
-
-	// change the LPSC values only if they are not already disabled
-	for(int i=0;i<LPSC_COUNT;i++){
-		if(saved_state.lpsc_value[i]!=0){
-			set_main_psc_state(psc_id[i],lpsc_id[i],PSC_PD_ON,PSC_DISABLE);
-		}
-	}
 
 	//DDR AUTO SELF REFRESH
 	mmio_write_32(EMIF_CTLCFG_DENALI_CTL_168,0x0000ff07);


### PR DESCRIPTION
Fixing the incorrect indexing of the lpsc_value array introduced in the standby flow.
Adding DEUBGSS LPSC in the list of LPSCs to be disabled in the low latency standby sequence to meet the 
requirements provided. Refactoring the code for allowing the above change to work. 