### PR TITLE
Port TISCI firewall APIs and AM62L firewall configuration from upstream 

### DIFF
--- a/drivers/ti/ti_sci/ti_sci.c
+++ b/drivers/ti/ti_sci/ti_sci.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -1809,6 +1810,178 @@ int ti_sci_boot_notification(void)
 		return -EINVAL;
 	}
 	VERBOSE("%s: boot notification received from TIFS\n", __func__);
+
+	return 0;
+}
+
+/**
+ * ti_sci_set_fwl_region - Request for configuring a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to set
+ * @control:            Contents of the firewall CONTROL register to set
+ * @permissions:        Contents of the firewall PERMISSION register to set
+ * @start_address:      Contents of the firewall START_ADDRESS register to set
+ * @end_address:        Contents of the firewall END_ADDRESS register to set
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t *permissions,
+			  uint64_t start_address, uint64_t end_address)
+{
+	struct ti_sci_msg_req_fwl_set_firewall_region req = { };
+	struct ti_sci_msg_resp_fwl_set_firewall_region resp = { };
+	struct ti_sci_xfer xfer = { };
+	unsigned int i;
+	int ret;
+
+	assert(n_permission_regs <= FWL_MAX_PRIVID_SLOTS);
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_SET, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.n_permission_regs = n_permission_regs;
+	req.control = control;
+	for (i = 0; i < n_permission_regs; i++)
+		req.permissions[i] = permissions[i];
+	req.start_address = start_address;
+	req.end_address = end_address;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_get_fwl_region - Request for getting a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to retrieve
+ * @control:            Contents of the firewall CONTROL register
+ * @permissions:        Contents of the firewall PERMISSION register
+ * @start_address:      Contents of the firewall START_ADDRESS register
+ * @end_address:        Contents of the firewall END_ADDRESS register
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t *permissions,
+			  uint64_t *start_address, uint64_t *end_address)
+{
+	struct ti_sci_msg_req_fwl_get_firewall_region req = { };
+	struct ti_sci_msg_resp_fwl_get_firewall_region resp = { };
+	struct ti_sci_xfer xfer = { };
+	unsigned int i;
+	int ret;
+
+	assert(n_permission_regs <= FWL_MAX_PRIVID_SLOTS);
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_GET, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.n_permission_regs = n_permission_regs;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*control = resp.control;
+	for (i = 0; i < n_permission_regs; i++)
+		permissions[i] = resp.permissions[i];
+	*start_address = resp.start_address;
+	*end_address = resp.end_address;
+
+	return 0;
+}
+
+/**
+ * ti_sci_change_fwl_owner() - Request for changing a firewall owner
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @owner_index:        New owner index to transfer ownership to
+ * @owner_privid:       New owner priv-ID returned by DMSC/TIFS. This field is
+ *                      currently initialized to zero by DMSC/TIFS.
+ * @owner_permission_bits: New owner permission bits returned by DMSC/TIFS. This
+ *                         field is currently initialized to zero by DMSC/TIFS.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits)
+{
+	struct ti_sci_msg_req_fwl_change_owner_info req = { };
+	struct ti_sci_msg_resp_fwl_change_owner_info resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TI_SCI_MSG_FWL_CHANGE_OWNER, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret != 0U) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.fwl_id = fwl_id;
+	req.region = region;
+	req.owner_index = owner_index;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0U) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*owner_privid = resp.owner_privid;
+	*owner_permission_bits = resp.owner_permission_bits;
 
 	return 0;
 }

--- a/drivers/ti/ti_sci/ti_sci.h
+++ b/drivers/ti/ti_sci/ti_sci.h
@@ -275,4 +275,49 @@ int ti_sci_lpm_get_next_sys_mode(uint8_t *next_mode);
  */
 int ti_sci_boot_notification(void);
 
+/**
+ * Firewall operations
+ *
+ * - ti_sci_set_fwl_region - Request for configuring a firewall region
+ *		@n_permission_regs: Number of permission registers to set
+ *		@control: Contents of the firewall CONTROL register to set
+ *		@permissions: Contents of the firewall PERMISSION register to set
+ *		@start_address: Contents of the firewall START_ADDRESS register to set
+ *		@end_address: Contents of the firewall END_ADDRESS register to set
+ * - ti_sci_get_fwl_region - Request for getting a firewall region configuration
+ *		@n_permission_regs: Number of permission registers retrieved
+ *		@control: Contents of the firewall CONTROL register
+ *		@permissions: Contents of the firewall PERMISSION register
+ *		@start_address: Contents of the firewall START_ADDRESS register
+ *		@end_address: Contents of the firewall END_ADDRESS register
+ * - ti_sci_change_fwl_owner - Request for changing a firewall owner
+ *		@owner_index: New owner index to transfer ownership to
+ *		@owner_privid: New owner priv-ID returned by DMSC/TIFS. This field is
+ *			       currently initialized to zero by DMSC/TIFS.
+ *		@owner_permission_bits: New owner permission bits returned by DMSC/TIFS. This
+ *				        field is currently initialized to zero by DMSC/TIFS.
+ *
+ * NOTE: for all these functions, the following are generic in nature:
+ * @fwl_id:	Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:	Region or channel number to set config info. This field
+ *		is unused in case of a simple firewall and must be
+ *		initialized to zero. In case of a region based
+ *		firewall, this field indicates the region in question
+ *		(index starting from 0). In case of a channel based
+ *		firewall, this field indicates the channel in question
+ *		(index starting from 0).
+ * Returns 0 for successful request, else returns corresponding error message.
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t *permissions,
+			  uint64_t start_address, uint64_t end_address);
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t *permissions,
+			  uint64_t *start_address, uint64_t *end_address);
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits);
+
 #endif /* TI_SCI_H */

--- a/drivers/ti/ti_sci/ti_sci_protocol.h
+++ b/drivers/ti/ti_sci/ti_sci_protocol.h
@@ -54,6 +54,11 @@
 #define TISCI_MSG_GET_PROC_BOOT_STATUS	0xc400
 #define TISCI_MSG_WAIT_PROC_BOOT_STATUS	0xc401
 
+/* Security Management Messages */
+#define TI_SCI_MSG_FWL_SET		0x9000
+#define TI_SCI_MSG_FWL_GET		0x9001
+#define TI_SCI_MSG_FWL_CHANGE_OWNER	0x9002
+
 /**
  * struct ti_sci_secure_msg_hdr - Header that prefixes all TISCI messages sent
  *				  via secure transport.
@@ -823,6 +828,129 @@ struct ti_sci_msg_resp_lpm_get_next_sys_mode {
 struct tisci_msg_boot_notification_msg {
 	struct ti_sci_msg_hdr hdr;
 	uint32_t extboot_status;
+} __packed;
+
+/* FWL_MAX_PRIVID_SLOTS must be defined with same value in ti_sci.h */
+#define FWL_MAX_PRIVID_SLOTS			3U
+
+/**
+ * struct ti_sci_msg_req_fwl_set_firewall_region - Set firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to set
+ * @control:		Contents of the firewall CONTROL register to set
+ * @permissions:	Contents of the firewall PERMISSION register to set
+ * @start_address:	Contents of the firewall START_ADDRESS register to set
+ * @end_address:	Contents of the firewall END_ADDRESS register to set
+ */
+struct ti_sci_msg_req_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+struct ti_sci_msg_resp_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_get_firewall_region - Retrieve firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to get config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to retrieve
+ */
+struct ti_sci_msg_req_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_get_firewall_region - Response for retrieving the
+ *						    firewall permissions
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to get config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers retrieved
+ * @control:		Contents of the firewall CONTROL register
+ * @permissions:	Contents of the firewall PERMISSION registers
+ * @start_address:	Contents of the firewall START_ADDRESS register
+ * @end_address:	Contents of the firewall END_ADDRESS register
+ */
+struct ti_sci_msg_resp_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_change_owner_info - Request change firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number if applicable
+ * @owner_index:	New owner index to transfer ownership to
+ */
+struct ti_sci_msg_req_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_change_owner_info - Response for change
+ *						  firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID specified in request
+ * @region:		Region or channel number specified in request
+ * @owner_index:	Owner index specified in request
+ * @owner_privid:	New owner priv-ID returned by DMSC/TIFS.
+ * @owner_permission_bits:	New owner permission bits returned by DMSC/TIFS.
+ */
+struct ti_sci_msg_resp_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+	uint8_t owner_privid;
+	uint16_t owner_permission_bits;
 } __packed;
 
 #endif /* TI_SCI_PROTOCOL_H */

--- a/plat/ti/k3low/common/am62l_bl31_setup.c
+++ b/plat/ti/k3low/common/am62l_bl31_setup.c
@@ -14,6 +14,7 @@
 #include <ti_clk_handler.h>
 
 #include <board_def.h>
+#include <firewall.h>
 #include <plat_private.h>
 
 /* Table of regions to map using the MMU */
@@ -55,6 +56,9 @@ int ti_soc_init(void)
 	       version.abi_major, version.abi_minor,
 	       version.firmware_revision,
 	       version.firmware_description);
+
+	/* Update firewall configurations */
+	update_fwl_configs();
 
 	ret = ti_sci_proc_request(PLAT_PROC_START_ID);
 	if (ret != 0) {

--- a/plat/ti/k3low/common/drivers/firewall/firewall.h
+++ b/plat/ti/k3low/common/drivers/firewall/firewall.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Texas Instruments Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FIREWALL_H
+#define FIREWALL_H
+
+#include <stdint.h>
+
+#include <lib/utils_def.h>
+
+#define TFA_HOST_ID		10U
+#define A53_PRIV_ID		4U
+#define FW_BACKGROUND_BIT	BIT(8U)
+
+/* Firewall IDs */
+#define OSPI_FWL_ID		97U
+#define ADC_MCASP_FWL_ID	160U
+
+/* Number of firewall regions */
+#define OSPI_FWL_NUM_REGIONS		8U
+#define ADC_MCASP_FWL_NUM_REGIONS	16U
+
+enum k3_fwl_region_type {
+	K3_FWL_REGION_FOREGROUND = 0,
+	K3_FWL_REGION_BACKGROUND = FW_BACKGROUND_BIT,
+};
+
+struct fwl_data {
+	uint16_t fwl_id;
+	uint8_t num_regions;
+};
+
+/*
+ * Updates firewall configurations by disabling ROM-configured firewalls.
+ * This function should be called during boot initialization and after
+ * resume from low power mode to ensure firewall regions that were
+ * configured by ROM for the boot phase are properly disabled.
+ */
+void update_fwl_configs(void);
+
+#endif /* FIREWALL_H */

--- a/plat/ti/k3low/common/drivers/firewall/firewall_config.c
+++ b/plat/ti/k3low/common/drivers/firewall/firewall_config.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Texas Instruments Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <common/debug.h>
+#include <ti_sci.h>
+#include <ti_sci_protocol.h>
+
+#include "firewall.h"
+
+const struct fwl_data fwls[] = {
+	{OSPI_FWL_ID, OSPI_FWL_NUM_REGIONS},	/* OSPI */
+	{ADC_MCASP_FWL_ID, ADC_MCASP_FWL_NUM_REGIONS},	/* ADC and MCASP */
+};
+
+/*
+ * Disable firewall by clearing firewall configurations for a given firewall
+ * ID and region type.
+ * This function iterates through all regions of the specified firewall,
+ * takes ownership, reads the current configuration, and disables any
+ * active firewall regions of the requested type (foreground or background).
+ *
+ * @fwl: Firewall data containing the firewall ID and number of regions
+ * @fwl_type: Type of firewall region to disable (foreground or background)
+ */
+static void remove_fwl_configs(struct fwl_data fwl, enum k3_fwl_region_type fwl_type)
+{
+	uint8_t owner_index = TFA_HOST_ID;
+	uint8_t owner_privid = A53_PRIV_ID;
+	uint16_t owner_permission_bits = 0;
+	uint32_t control = 0;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
+	uint32_t n_permission_regs = FWL_MAX_PRIVID_SLOTS;
+	uint64_t start_address = 0;
+	uint64_t end_address = 0;
+	int ret = 0;
+
+	for (int i = 0; i < fwl.num_regions; i++) {
+		ret = ti_sci_change_fwl_owner(fwl.fwl_id, i, owner_index,
+					      &owner_privid, &owner_permission_bits);
+		if (ret) {
+			ERROR("Could not change firewall owner (%d)\n", ret);
+			continue;
+		}
+
+		ret = ti_sci_get_fwl_region(fwl.fwl_id, i, n_permission_regs,
+					    &control, permissions,
+					    &start_address, &end_address);
+		if (ret) {
+			ERROR("Could not get firewall region information (%d)\n", ret);
+			continue;
+		}
+
+		/* If the region is already disabled, then simply skip it */
+		if (control == 0)
+			continue;
+
+		/* If the region is configured as the same type as fwl_type, then disable it */
+		if ((control & FW_BACKGROUND_BIT) == fwl_type) {
+			control = 0;
+
+			ret = ti_sci_set_fwl_region(fwl.fwl_id, i, n_permission_regs,
+						    control, permissions,
+						    start_address, end_address);
+			if (ret) {
+				ERROR("Could not disable firewall region (%d)\n", ret);
+				panic();
+			}
+		}
+	}
+}
+
+void update_fwl_configs(void)
+{
+	/*
+	 * Disable firewalls that were configured by ROM for boot phase.
+	 *
+	 * While removing the firewalls, disabling the background region causes
+	 * all the transactions not covered by a foreground region to be blocked.
+	 * This causes a race for any entity trying to access that memory
+	 * region before all the foreground regions are disabled, at which point
+	 * the firewall as a whole is disabled and transactions may pass.
+	 * Iterate the loop twice, removing the foregrounds first and then background.
+	 */
+	for (int i = 0; i < ARRAY_SIZE(fwls); i++) {
+		remove_fwl_configs(fwls[i], K3_FWL_REGION_FOREGROUND);
+		remove_fwl_configs(fwls[i], K3_FWL_REGION_BACKGROUND);
+	}
+}

--- a/plat/ti/k3low/platform.mk
+++ b/plat/ti/k3low/platform.mk
@@ -93,6 +93,7 @@ PLAT_INCLUDES +=	\
 			-Idrivers/scmi-msg				\
 			-Iplat/ti/common/include			\
 			-Iplat/ti/common/scmi				\
+			-I${PLAT_PATH}/common/drivers/firewall		\
 
 K3_PSCI_SOURCES		+=	\
 				${PLAT_PATH}/common/am62l_psci.c	\
@@ -106,6 +107,7 @@ BL31_SOURCES		+=	\
 				${K3_TI_SCI_TRANSPORT}				\
 				${PLAT_PATH}/common/am62l_bl31_setup.c		\
 				${PLAT_PATH}/common/am62l_topology.c		\
+				${PLAT_PATH}/common/drivers/firewall/firewall_config.c	\
 
 BL1_SOURCES		+=	\
 				${K3_TI_SCI_TRANSPORT}				\


### PR DESCRIPTION
This PR ports the following two patches from upstream:

 - 481aabb1c ("feat(ti): add support for TISCI firewall APIs")
 - 6af16d179 ("feat(k3low): re-configure firewalls for TI AM62L")

The first commit adds TI_SCI APIs for firewall manipulation (getting firewall config, setting firewall config, and changing firewall owner).

The second commit adds code for configuring firewalls for AM62L during soc init, to disable ROM configured firewalls which cause a crash n HS-SE boards due to firewall exceptions. 