### PR TITLE
LTS Migration: Backport "Add support for fusing OTP bits"

### DIFF
--- a/drivers/ti/ti_sci/ti_sci.c
+++ b/drivers/ti/ti_sci/ti_sci.c
@@ -2024,3 +2024,120 @@ int ti_sci_keywriter_lite(unsigned long addr)
 
 	return 0;
 }
+
+/**
+ * ti_sci_read_otp() - Read OTP data from the OTP controller
+ *
+ * @param bank The bank number to read from
+ * @param word The word number to read
+ * @param val  Pointer to read value
+ *
+ * Return: 0 if all goes well, else appropriate error code
+ */
+int ti_sci_read_otp(uint8_t bank, uint32_t word, uint32_t *val)
+{
+	struct tisci_msg_read_otp_mmr_req req;
+	struct tisci_msg_read_otp_mmr_resp resp;
+
+	struct ti_sci_xfer xfer;
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TISCI_MSG_READ_OTP_MMR, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.mmr_idx = word;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*val = resp.mmr_val;
+
+	return ret;
+}
+
+/**
+ * ti_sci_write_otp() - Writes a value to the OTP controller
+ *
+ * @param bank The OTP bank to write to.
+ * @param word The word index to write.
+ * @param val The value to write.
+ * @param mask The mask for the value to be written.
+ * @param val_out A pointer to the value that was written as readback.
+ *
+ * @return Returns 0 on success, or a negative value on failure, with the error code indicating the specific error.
+ */
+int ti_sci_write_otp(uint8_t bank, uint32_t word, uint32_t val_in, uint32_t mask, uint32_t *val_out)
+{
+	struct tisci_msg_write_otp_mmr_req req;
+	struct tisci_msg_write_otp_mmr_resp resp;
+
+	struct ti_sci_xfer xfer;
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TISCI_MSG_WRITE_OTP_MMR, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.row_idx = word;
+	req.row_val = val_in;
+	req.row_mask = mask;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret) {
+		ERROR("Transfer send failed (%d)\n", ret);
+		return ret;
+	}
+
+	*val_out = resp.row_val;
+
+	return ret;
+}
+
+/**
+ * ti_sci_set_otp_bootmode() - Set OTP boot mode
+ *
+ * @param index The OTP index to set the boot mode for.
+ * @param mode The OTP boot mode to set.
+ *
+ * Returns 0 on success, or a negative value on failure, with the error code indicating the specific error.
+ */
+int ti_sci_set_otp_bootmode(uint8_t index, uint32_t mode)
+{
+	struct tisci_msg_set_otp_bootmode_req req = { 0 };
+	struct tisci_msg_set_otp_bootmode_resp resp;
+
+	struct ti_sci_xfer xfer;
+	int ret;
+
+	ret = ti_sci_setup_one_xfer(TISCI_MSG_SET_OTP_BOOT_MODE, 0,
+				    &req, sizeof(req),
+				    &resp, sizeof(resp),
+				    &xfer);
+	if (ret) {
+		ERROR("Message alloc failed (%d)\n", ret);
+		return ret;
+	}
+
+	req.boot_mode_efuse_idx = index;
+	req.write_val = mode;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		ERROR("Transfer send failed (%d)\n", ret);
+
+	return ret;
+}

--- a/drivers/ti/ti_sci/ti_sci.h
+++ b/drivers/ti/ti_sci/ti_sci.h
@@ -333,4 +333,37 @@ int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
  */
 int ti_sci_keywriter_lite(unsigned long addr);
 
+/**
+ * OTP Operations
+ *
+ * - ti_sci_read_otp - Command to read OTP data from the OTP controller.
+ *		@bank: The bank number to read from.
+ *		@word: The word number to read from.
+ *		@val: A pointer to the value to be read.
+
+ * Returns 0 for successful request, else returns corresponding error code on failure.
+ */
+int ti_sci_read_otp(uint8_t bank, uint32_t word, uint32_t *val);
+
+/**
+ * - ti_sci_write_otp - Command to write OTP data to the OTP controller.
+ *		@bank: The bank number to write to.
+ *		@word: The word number to write to.
+ *		@val_in: The value to be written.
+ *		@mask: The mask for the value to be written.
+ *		@val_out: A pointer to the value that was written as readback.
+ *
+ * Returns 0 for successful request, else returns corresponding error code on failure.
+ */
+int ti_sci_write_otp(uint8_t bank, uint32_t word, uint32_t val_in, uint32_t mask, uint32_t *val_out);
+
+/**
+ * - ti_sci_set_otp_bootmode - Command to set OTP boot mode eFuses.
+ *		@idx: The efuse index within the bootmode OTP bank.
+ *		@bootmode: The OTP boot mode value to set.
+ *
+ * Returns 0 for successful request, else returns corresponding error code on failure.
+ */
+int ti_sci_set_otp_bootmode(uint8_t idx, uint32_t bootmode);
+
 #endif /* TI_SCI_H */

--- a/drivers/ti/ti_sci/ti_sci_protocol.h
+++ b/drivers/ti/ti_sci/ti_sci_protocol.h
@@ -59,6 +59,13 @@
 #define TI_SCI_MSG_FWL_GET		0x9001
 #define TI_SCI_MSG_FWL_CHANGE_OWNER	0x9002
 
+/* OTP MMR messages */
+#define TISCI_MSG_READ_OTP_MMR		0x9022
+#define TISCI_MSG_WRITE_OTP_MMR 	0x9023
+
+/* Set OTP Boot Mode TISCI message */
+#define TISCI_MSG_SET_OTP_BOOT_MODE	0x9044
+
 /* Keywriter lite TISCI message to write keys from a buffer */
 #define TISCI_MSG_KEY_WRITER_LITE	0x9045
 
@@ -983,6 +990,80 @@ struct ti_sci_msg_req_keywriter_lite {
 struct ti_sci_msg_resp_keywriter_lite {
 	struct ti_sci_msg_hdr hdr;
 	uint32_t debug_response;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_read_otp_mmr - Request for reading OTP MMRs.
+ *
+ * @hdr             Generic Header
+ * @mmr_idx         Index of MMR to read
+ *
+ * Request type is TISCI_MSG_READ_OTP_MMR, response is appropriate
+ * message, or NACK in case of inability to satisfy request.
+ */
+struct tisci_msg_read_otp_mmr_req {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t mmr_idx;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_read_otp_mmr - Response for reading OTP MMRs.
+ * @hdr             Generic Header
+ * @mmr_val         Value of MMR read
+ */
+struct tisci_msg_read_otp_mmr_resp {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t mmr_val;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_write_otp_mmr - Request for writing OTP MMRs.
+ *
+ * @hdr             Generic Header
+ * @row_idx         Index of row to write
+ * @row_val         Value to write to the row
+ * @row_mask        Mask to apply to the row value
+ *
+ * Request type is TISCI_MSG_WRITE_OTP_MMR, response is appropriate
+ * message, or NACK in case of inability to satisfy request.
+ */
+struct tisci_msg_write_otp_mmr_req {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t row_idx;
+	uint32_t row_val;
+	uint32_t row_mask;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_write_otp_mmr - Response for writing OTP MMRs.
+ * @hdr             Generic Header
+ * @row_val         Value written to the row
+ */
+struct tisci_msg_write_otp_mmr_resp {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t row_val;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_set_otp_bootmode - Request for setting OTP bootmode.
+ * @hdr                 Generic Header
+ * @boot_mode_efuse_idx Boot mode efuse index
+ * @reserved            Reserved space in message, must be 0 for backward compatibility
+ * @write_val           Value to write to the efuse
+ */
+struct tisci_msg_set_otp_bootmode_req {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t boot_mode_efuse_idx;
+	uint8_t reserved[3];
+	uint32_t write_val;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_set_otp_bootmode - Response for setting OTP bootmode.
+ * @hdr Generic Header
+ */
+struct tisci_msg_set_otp_bootmode_resp {
+	struct ti_sci_msg_hdr hdr;
 } __packed;
 
 #endif /* TI_SCI_PROTOCOL_H */

--- a/plat/ti/common/include/k3_sip_svc.h
+++ b/plat/ti/common/include/k3_sip_svc.h
@@ -15,13 +15,15 @@
 #define SIP_SVC_VERSION		0x8200ff03
 #define K3_SIP_SCMI_AGENT0	0x82004000
 #define K3_SIP_OTP_WRITEBUFF    0xC2000000
+#define K3_SIP_OTP_WRITE        0xC2000001
+#define K3_SIP_OTP_READ         0xC2000002
 
 /* TI SiP Service Calls version numbers */
 #define K3_SIP_SVC_VERSION_MAJOR	0x0
 #define K3_SIP_SVC_VERSION_MINOR	0x1
 
 /* Number of TI SiP Calls implemented */
-#define K3_COMMON_SIP_NUM_CALLS		0x4
+#define K3_COMMON_SIP_NUM_CALLS     0x6
 
 /* TI Fuse writebuff SMC handler */
 int ti_fuse_writebuff_handler(u_register_t x1);

--- a/plat/ti/common/k3_svc.c
+++ b/plat/ti/common/k3_svc.c
@@ -11,9 +11,10 @@
 #include <common/runtime_svc.h>
 #include <drivers/scmi-msg.h>
 
-#include <lib/mmio.h>
-#include <tools_share/uuid.h>
 #include <k3_sip_svc.h>
+#include <lib/mmio.h>
+#include <ti_sci.h>
+#include <tools_share/uuid.h>
 
 /* K3 SiP Service UUID */
 DEFINE_SVC_UUID2(ti_sip_svc_uid,
@@ -32,11 +33,12 @@ uintptr_t sip_smc_handler(uint32_t smc_fid,
 			  void *handle,
 			  u_register_t flags)
 {
+	int ret = SMC_UNK;
+
 	switch (smc_fid) {
 	case SIP_SVC_CALL_COUNT:
 		/* Return the number of TI K3 SiP Service Calls. */
-		SMC_RET1(handle,
-			 K3_COMMON_SIP_NUM_CALLS);
+		SMC_RET1(handle, K3_COMMON_SIP_NUM_CALLS);
 
 	case SIP_SVC_UID:
 		/* Return UID to the caller */
@@ -53,6 +55,42 @@ uintptr_t sip_smc_handler(uint32_t smc_fid,
 
 	case K3_SIP_OTP_WRITEBUFF:
 		SMC_RET1(handle, ti_fuse_writebuff_handler(x1));
+
+	case K3_SIP_OTP_READ:
+		uint32_t mmr_val = 0;
+
+		/*
+		 * 0x00 - 0xFE is reserved for user OTP, 0xFF is
+		 * reserved for bootmode OTP which doesnt support
+		 * readback
+		 */
+		if (x1 < 0xff)
+			ret = ti_sci_read_otp(x1, x2, &mmr_val);
+		else
+			ERROR("%s: (K3_SIP_OTP_READ) tried reading from invalid bank '0x%lx'\n",
+			      __func__, x1);
+
+		SMC_RET2(handle, ret, mmr_val);
+
+	case K3_SIP_OTP_WRITE:
+		/*
+		 * 0x00 - 0xFE is reserved for user OTP, 0xFF is
+		 * reserved for bootmode OTP programming
+		 */
+		if (x1 < 0xff) {
+			uint32_t row_val = 0;
+
+			ret = ti_sci_write_otp(x1, x2, x3, x4, &row_val);
+
+			SMC_RET2(handle, ret, row_val);
+		} else if (x1 == 0xff) {
+			SMC_RET2(handle, ti_sci_set_otp_bootmode(x2, x3), x3);
+		} else {
+			ERROR("%s: (K3_SIP_OTP_WRITE) tried writing to invalid bank '0x%lx'\n",
+			      __func__, x1);
+		}
+
+		SMC_RET1(handle, SMC_UNK);
 
 	default:
 		ERROR("%s: unhandled SMC (0x%x)\n", __func__, smc_fid);


### PR DESCRIPTION
This PR backports the changes required to support OTP fusing from the previous LTS [#27] from @r-vignesh.