### PR TITLE
PENDING: feat(k3low): Optimize firewall configuration to minimize boot time

### DIFF
--- a/plat/ti/k3low/common/drivers/firewall/firewall.h
+++ b/plat/ti/k3low/common/drivers/firewall/firewall.h
@@ -15,22 +15,31 @@
 #define A53_PRIV_ID		4U
 #define FW_BACKGROUND_BIT	BIT(8U)
 
+#define DDR_BASE		0x80000000
+#define DDR_SIZE		0x7FFFFFFF
+
 /* Firewall IDs */
 #define OSPI_FWL_ID		97U
 #define ADC_MCASP_FWL_ID	160U
+#define DDR_FWL_ID		1U
 
-/* Number of firewall regions */
-#define OSPI_FWL_NUM_REGIONS		8U
-#define ADC_MCASP_FWL_NUM_REGIONS	16U
+/* Firewall regions to disable */
+#define OSPI_FWL_REGION		0U
+#define ADC_MCASP_FWL_REGION	0U
 
-enum k3_fwl_region_type {
-	K3_FWL_REGION_FOREGROUND = 0,
-	K3_FWL_REGION_BACKGROUND = FW_BACKGROUND_BIT,
-};
+/* Firewall Regions to configure */
+#define DDR_BG_REGION		0U
+
+/* Firewall Control Register Values */
+#define FWL_CTRL_EN		0xA
+#define FWL_CTRL_EN_BG		(FWL_CTRL_EN | FW_BACKGROUND_BIT)
+
+/* Firewall permission values */
+#define FWL_PERM_ALL_RW		0xC3BBBB /* RW access to ALL hosts */
 
 struct fwl_data {
 	uint16_t fwl_id;
-	uint8_t num_regions;
+	uint8_t region;
 };
 
 /*

--- a/plat/ti/k3low/common/drivers/firewall/firewall_config.c
+++ b/plat/ti/k3low/common/drivers/firewall/firewall_config.c
@@ -11,81 +11,52 @@
 #include "firewall.h"
 
 const struct fwl_data fwls[] = {
-	{OSPI_FWL_ID, OSPI_FWL_NUM_REGIONS},	/* OSPI */
-	{ADC_MCASP_FWL_ID, ADC_MCASP_FWL_NUM_REGIONS},	/* ADC and MCASP */
+	{OSPI_FWL_ID, OSPI_FWL_REGION},	/* OSPI */
+	{ADC_MCASP_FWL_ID, ADC_MCASP_FWL_REGION},	/* ADC and MCASP */
 };
 
 /*
- * Disable firewall by clearing firewall configurations for a given firewall
- * ID and region type.
- * This function iterates through all regions of the specified firewall,
- * takes ownership, reads the current configuration, and disables any
- * active firewall regions of the requested type (foreground or background).
- *
- * @fwl: Firewall data containing the firewall ID and number of regions
- * @fwl_type: Type of firewall region to disable (foreground or background)
+ * Take ownership and set the configuration for a given firewall ID and region.
+ * Function arguments are same as those which will be passed to
+ * ti_sci_set_fwl_region()
  */
-static void remove_fwl_configs(struct fwl_data fwl, enum k3_fwl_region_type fwl_type)
+static void add_fwl_configs(const uint16_t fwl_id, const uint16_t region,
+			    const uint32_t n_perm_regs, const uint32_t control,
+			    const uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			    const uint64_t start_address, const uint64_t end_address)
 {
 	uint8_t owner_index = TFA_HOST_ID;
 	uint8_t owner_privid = A53_PRIV_ID;
 	uint16_t owner_permission_bits = 0;
-	uint32_t control = 0;
-	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
-	uint32_t n_permission_regs = FWL_MAX_PRIVID_SLOTS;
-	uint64_t start_address = 0;
-	uint64_t end_address = 0;
 	int ret = 0;
 
-	for (int i = 0; i < fwl.num_regions; i++) {
-		ret = ti_sci_change_fwl_owner(fwl.fwl_id, i, owner_index,
-					      &owner_privid, &owner_permission_bits);
-		if (ret) {
-			ERROR("Could not change firewall owner (%d)\n", ret);
-			continue;
-		}
+	ret = ti_sci_change_fwl_owner(fwl_id, region, owner_index,
+				      &owner_privid, &owner_permission_bits);
+	if (ret) {
+		ERROR("Could not change firewall owner (%d)\n", ret);
+		panic();
+	}
 
-		ret = ti_sci_get_fwl_region(fwl.fwl_id, i, n_permission_regs,
-					    &control, permissions,
-					    &start_address, &end_address);
-		if (ret) {
-			ERROR("Could not get firewall region information (%d)\n", ret);
-			continue;
-		}
-
-		/* If the region is already disabled, then simply skip it */
-		if (control == 0)
-			continue;
-
-		/* If the region is configured as the same type as fwl_type, then disable it */
-		if ((control & FW_BACKGROUND_BIT) == fwl_type) {
-			control = 0;
-
-			ret = ti_sci_set_fwl_region(fwl.fwl_id, i, n_permission_regs,
-						    control, permissions,
-						    start_address, end_address);
-			if (ret) {
-				ERROR("Could not disable firewall region (%d)\n", ret);
-				panic();
-			}
-		}
+	ret = ti_sci_set_fwl_region(fwl_id, region, n_perm_regs,
+				    control, permissions,
+				    start_address, end_address);
+	if (ret) {
+		ERROR("Could not set firewall region (%d)\n", ret);
+		panic();
 	}
 }
 
 void update_fwl_configs(void)
 {
-	/*
-	 * Disable firewalls that were configured by ROM for boot phase.
-	 *
-	 * While removing the firewalls, disabling the background region causes
-	 * all the transactions not covered by a foreground region to be blocked.
-	 * This causes a race for any entity trying to access that memory
-	 * region before all the foreground regions are disabled, at which point
-	 * the firewall as a whole is disabled and transactions may pass.
-	 * Iterate the loop twice, removing the foregrounds first and then background.
-	 */
+	uint32_t permissions[3] = {0};
+	/* Disable firewalls that were configured by ROM for boot phase. */
 	for (int i = 0; i < ARRAY_SIZE(fwls); i++) {
-		remove_fwl_configs(fwls[i], K3_FWL_REGION_FOREGROUND);
-		remove_fwl_configs(fwls[i], K3_FWL_REGION_BACKGROUND);
+		add_fwl_configs(fwls[i].fwl_id, fwls[i].region, FWL_MAX_PRIVID_SLOTS,
+				0, permissions, 0x0, UINT32_MAX);
 	}
+
+	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_ALL_RW;
+	add_fwl_configs(DDR_FWL_ID, DDR_BG_REGION, 3, FWL_CTRL_EN_BG,
+			permissions, DDR_BASE, DDR_BASE + DDR_SIZE);
+
 }


### PR DESCRIPTION
Currently, ROM configured firewalls are removed during SOC init for AM62L by iterating over all regions of the firewalls and then taking action if they are active. This has a major hit on the boot time as TISCI calls are expensive.

Instead, obtain the list of regions configured by ROM and the respective permissions, and then only go on to disable those regions. For DDR, add a permissive configuration instead of disabling. This greatly reduces the number of TISCI calls we are making, and hence minimizes boot time impact.

Change-Id: I88aba2def73c43894e9d332c35700c462d70fe4f

---

Boot tested on both HS-FS and HS-SE boards.
Time taken by firewall configuration reduced from ~2s to ~120ms