### PR TITLE
Modify plat_get_target_pwr_state() for cluster level

### DIFF
--- a/plat/ti/k3low/common/am62l_psci.c
+++ b/plat/ti/k3low/common/am62l_psci.c
@@ -118,7 +118,7 @@ static void am62l_pwr_down_domain(const psci_power_state_t *target_state)
 	core = plat_my_core_pos();
 
 	/* If our cluster is not going down we stop here */
-	if (CLUSTER_PWR_STATE(target_state) != PLAT_MAX_OFF_STATE) {
+	if (SYSTEM_PWR_STATE(target_state) != PLAT_MAX_OFF_STATE) {
 		VERBOSE("%s: A53 CORE: %d OFF\n", __func__, core);
 		set_main_psc_state(PD_MPU_CLST_CORE_0 + core, LPSC_MAIN_MPU_CLST_CORE_0 + core,
 				   PSC_PD_OFF, PSC_SYNCRESETDISABLE);
@@ -317,7 +317,7 @@ plat_local_state_t plat_get_target_pwr_state(unsigned int lvl,
 		 *	Thus the target power state for the cluster is the minimum of the power states
 		 *	requested by all the cores that is not RUN.
 		 */
-		if (temp < target)
+		if ((temp < target) && ((temp != PSCI_LOCAL_STATE_RUN) || (lvl != MPIDR_AFFLVL1)))
 			target = temp;
 		n--;
 	} while (n > 0U);


### PR DESCRIPTION
The default implementation of plat_get_target_pwr_state() selects the lowest requested power state among all CPUs at a given power level.

In cluster standby mode, the first CPU entering idle takes the CPU-standby fast path and does not update the psci_req_pwr_state[] array. As a result, its entry remains at the default PSCI_LOCAL_STATE_RUN(0), which represents the lowest power state.

When the second CPU requests cluster standby, the state coordination logic observes this stale RUN entry and rejects the standby transition, since the decided target state by plat_get_target_pwr_state() resolves to RUN. Fix this by updating plat_get_target_pwr_state() for power level 1 (cluster level) to ignore PSCI_LOCAL_STATE_RUN when computing the target state. This ensures that CPUs taking the standby fast path do not block valid cluster-level standby entry.

Additionally, update am62l_pwr_down_domain() to check the system power state instead of cluster due to the above mentioned change, to prevent unintented core shutdown when target state is not PLAT_MAX_OFF_STATE.