### PR TITLE
feat(k3low): Add foreground firewall regions over BL31 and BL32

### DIFF
--- a/plat/ti/k3low/common/drivers/firewall/firewall.h
+++ b/plat/ti/k3low/common/drivers/firewall/firewall.h
@@ -29,6 +29,8 @@
 
 /* Firewall Regions to configure */
 #define DDR_BG_REGION		0U
+#define DDR_BL31_REGION		1U
+#define DDR_BL32_REGION		2U
 
 /* Firewall Control Register Values */
 #define FWL_CTRL_EN		0xA
@@ -36,6 +38,7 @@
 
 /* Firewall permission values */
 #define FWL_PERM_ALL_RW		0xC3BBBB /* RW access to ALL hosts */
+#define FWL_PERM_SEC_RW		0x400BB
 
 struct fwl_data {
 	uint16_t fwl_id;

--- a/plat/ti/k3low/common/drivers/firewall/firewall_config.c
+++ b/plat/ti/k3low/common/drivers/firewall/firewall_config.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <common/bl_common.h>
 #include <common/debug.h>
 #include <ti_sci.h>
 #include <ti_sci_protocol.h>
@@ -58,5 +59,12 @@ void update_fwl_configs(void)
 	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_ALL_RW;
 	add_fwl_configs(DDR_FWL_ID, DDR_BG_REGION, 3, FWL_CTRL_EN_BG,
 			permissions, DDR_BASE, DDR_BASE + DDR_SIZE);
+
+	/* Configure foreground firewall for TF-A and OP-TEE */
+	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_SEC_RW;
+	add_fwl_configs(DDR_FWL_ID, DDR_BL31_REGION, 3, FWL_CTRL_EN, permissions,
+			BL31_START, BL31_END);
+	add_fwl_configs(DDR_FWL_ID, DDR_BL32_REGION, 3, FWL_CTRL_EN, permissions,
+			BL32_BASE, BL32_BASE + BL32_SIZE - 1);
 
 }

--- a/plat/ti/k3low/platform.mk
+++ b/plat/ti/k3low/platform.mk
@@ -85,6 +85,9 @@ BL1_SOURCES		+=	\
 BL32_BASE ?= 0x80200000
 $(eval $(call add_define,BL32_BASE))
 
+BL32_SIZE ?= 0x1800000
+$(eval $(call add_define,BL32_SIZE))
+
 PRELOADED_BL33_BASE ?= 0x82000000
 $(eval $(call add_define,PRELOADED_BL33_BASE))
 


### PR DESCRIPTION
Add foreground firewall regions to protect BL31 and BL32 memory regions from read and write access by non-secure entities.

Tested this on SR1.1. 

cc: @glneo @ti-kamlesh @r-vignesh 