### PR TITLE
PENDING: fix(k3low): move context save addr

### DIFF
--- a/plat/ti/k3low/common/am62l_bl1_setup.c
+++ b/plat/ti/k3low/common/am62l_bl1_setup.c
@@ -168,7 +168,7 @@ static void __dead2 k3_bl1_handoff(void)
 		a53_tifs_msg_obj.req.hdr.host = 0xA;
 		a53_tifs_msg_obj.req.hdr.seq = 0x12;
 		a53_tifs_msg_obj.req.hdr.type = 0x0308;
-		a53_tifs_msg_obj.req.ctx_lo = 0x80A00000U;
+		a53_tifs_msg_obj.req.ctx_lo = TIFS_LPM_SAVE_CTX;
 		a53_tifs_msg_obj.req.ctx_hi = 0x00000000U;
 
 		ti_sci_boot_notification();

--- a/plat/ti/k3low/common/am62l_psci.c
+++ b/plat/ti/k3low/common/am62l_psci.c
@@ -230,7 +230,7 @@ static void am62l_pwr_domain_suspend(const psci_power_state_t *target_state)
 	uint32_t core, proc_id;
 	uint32_t mode = 0;
 	core = plat_my_core_pos();
-	uint64_t context_save_addr = 0x80A00000;
+	uint64_t context_save_addr = TIFS_LPM_SAVE_CTX;
 
 	assert(core < 2U);
 

--- a/plat/ti/k3low/platform.mk
+++ b/plat/ti/k3low/platform.mk
@@ -88,6 +88,9 @@ $(eval $(call add_define,BL32_BASE))
 PRELOADED_BL33_BASE ?= 0x82000000
 $(eval $(call add_define,PRELOADED_BL33_BASE))
 
+TIFS_LPM_SAVE_CTX ?= 0x81A00000
+$(eval $(call add_define,TIFS_LPM_SAVE_CTX))
+
 K3_HW_CONFIG_BASE ?= 0x88000000
 $(eval $(call add_define,K3_HW_CONFIG_BASE))
 PLAT_INCLUDES +=	\


### PR DESCRIPTION
Move the LPM context save address to the end of OPTEE. This is needed to avoid overwriting the firewalled region which is reserved only for usage by OPTEE.

Change-Id: Ife8f6c54acaf5759740c4eb5db3b5f6d67b03061