### PR TITLE
Refactor and configure BL31 and BL32 firewalls

### DIFF
--- a/plat/ti/k3low/common/am62l_bl31_setup.c
+++ b/plat/ti/k3low/common/am62l_bl31_setup.c
@@ -60,7 +60,10 @@ int ti_soc_init(void)
 	       version.firmware_revision,
 	       version.firmware_description);
 
-	/* Update firewall configurations */
+
+	/* WORKAROUND: Open up ROM's bad firewall configurations */
+	open_rom_fwl();
+	/* Apply firewall configurations over BL31 and BL32 memory regions */
 	update_fwl_configs();
 
 	ret = ti_sci_proc_request(PLAT_PROC_START_ID);

--- a/plat/ti/k3low/common/am62l_psci.c
+++ b/plat/ti/k3low/common/am62l_psci.c
@@ -369,8 +369,6 @@ static void am62l_pwr_domain_suspend_finish(const psci_power_state_t *target_sta
 		return;
 	}
 
-	/* Update firewall configurations */
-	update_fwl_configs();
 	/* Remove the I/O isolation */
 	k3low_lpm_set_io_isolation(false);
 	/* Initialize the console to provide early debug support */

--- a/plat/ti/k3low/common/drivers/firewall/firewall.h
+++ b/plat/ti/k3low/common/drivers/firewall/firewall.h
@@ -29,6 +29,8 @@
 
 /* Firewall Regions to configure */
 #define DDR_BG_REGION		0U
+#define DDR_BL31_REGION		1U
+#define DDR_BL32_REGION		2U
 
 /* Firewall Control Register Values */
 #define FWL_CTRL_EN		0xA
@@ -36,6 +38,7 @@
 
 /* Firewall permission values */
 #define FWL_PERM_ALL_RW		0xC3BBBB /* RW access to ALL hosts */
+#define FWL_PERM_SEC_RW		0x400BB
 
 struct fwl_data {
 	uint16_t fwl_id;

--- a/plat/ti/k3low/common/drivers/firewall/firewall.h
+++ b/plat/ti/k3low/common/drivers/firewall/firewall.h
@@ -43,10 +43,20 @@ struct fwl_data {
 };
 
 /*
- * Updates firewall configurations by disabling ROM-configured firewalls.
- * This function should be called during boot initialization and after
- * resume from low power mode to ensure firewall regions that were
- * configured by ROM for the boot phase are properly disabled.
+ * ROM makes bad firewall configurations that cause boot to fail. As a
+ * workaround, make these configurations permissive for all and keep them
+ * enabled. Keeping them permissive has the same effect as disabling them, and
+ * keeping them enabled causes TIFS to save their context during suspend and
+ * restore it during resume. Disabling those firewalls would lead to TIFS not
+ * restoring context correctly after ROM sets those firewalls again, during
+ * resume.
+ */
+void open_rom_fwl(void);
+
+/*
+ * Protects BL31 and BL32 memory regions by configuring restrictive foreground
+ * firewalls over them. Configures a permissive background firewall over rest of
+ * the DDR.
  */
 void update_fwl_configs(void);
 

--- a/plat/ti/k3low/common/drivers/firewall/firewall_config.c
+++ b/plat/ti/k3low/common/drivers/firewall/firewall_config.c
@@ -46,14 +46,21 @@ static void add_fwl_configs(const uint16_t fwl_id, const uint16_t region,
 	}
 }
 
+void open_rom_fwl(void)
+{
+	uint32_t permissions[3] = {0};
+
+	/* Open up firewalls that were configured by ROM for boot phase. */
+	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_ALL_RW;
+	for (int i = 0; i < ARRAY_SIZE(fwls); i++) {
+		add_fwl_configs(fwls[i].fwl_id, fwls[i].region, FWL_MAX_PRIVID_SLOTS,
+				FWL_CTRL_EN_BG, permissions, 0x0, 0xFFFFFFFFF);
+	}
+}
+
 void update_fwl_configs(void)
 {
 	uint32_t permissions[3] = {0};
-	/* Disable firewalls that were configured by ROM for boot phase. */
-	for (int i = 0; i < ARRAY_SIZE(fwls); i++) {
-		add_fwl_configs(fwls[i].fwl_id, fwls[i].region, FWL_MAX_PRIVID_SLOTS,
-				0, permissions, 0x0, UINT32_MAX);
-	}
 
 	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_ALL_RW;
 	add_fwl_configs(DDR_FWL_ID, DDR_BG_REGION, 3, FWL_CTRL_EN_BG,

--- a/plat/ti/k3low/common/drivers/firewall/firewall_config.c
+++ b/plat/ti/k3low/common/drivers/firewall/firewall_config.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <platform_def.h>
+
+#include <common/bl_common.h>
 #include <common/debug.h>
 #include <ti_sci.h>
 #include <ti_sci_protocol.h>
@@ -65,5 +68,12 @@ void update_fwl_configs(void)
 	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_ALL_RW;
 	add_fwl_configs(DDR_FWL_ID, DDR_BG_REGION, 3, FWL_CTRL_EN_BG,
 			permissions, DDR_BASE, DDR_BASE + DDR_SIZE);
+
+	/* Configure foreground firewall for TF-A and OP-TEE */
+	permissions[0] = permissions[1] = permissions[2] = FWL_PERM_SEC_RW;
+	add_fwl_configs(DDR_FWL_ID, DDR_BL31_REGION, 3, FWL_CTRL_EN, permissions,
+			BL31_START, BL31_START + BL31_SIZE - 1);
+	add_fwl_configs(DDR_FWL_ID, DDR_BL32_REGION, 3, FWL_CTRL_EN, permissions,
+			BL32_BASE, BL32_BASE + BL32_SIZE - 1);
 
 }

--- a/plat/ti/k3low/platform.mk
+++ b/plat/ti/k3low/platform.mk
@@ -85,6 +85,9 @@ BL1_SOURCES		+=	\
 BL32_BASE ?= 0x80200000
 $(eval $(call add_define,BL32_BASE))
 
+BL32_SIZE ?= 0x1800000
+$(eval $(call add_define,BL32_SIZE))
+
 PRELOADED_BL33_BASE ?= 0x82000000
 $(eval $(call add_define,PRELOADED_BL33_BASE))
 


### PR DESCRIPTION
This PR does 2 things:

1. it refactors the firewall removal code block into a separate function, and then calls only this (and not the function to add new configurations) in resume sequence.
2. it applies foreground firewall over BL31 and BL32 regions

The PR to do the 2nd thing had been made and merged earlier, but the sole commit was then reverted due to it causing regression in RTC+DDR LPM. The 1st commit in this PR addresses this regression.

Note: In U-boot stage, A53 does a speculative read into BL31's memory region. This leads to a firewall exception. Since its just a read, there's no crash. This read occurs regardless of this patch, but becomes visible only after applying a firewall. It needs to be fixed from U-boot's end. The exception doesn't obstruct boot beyond just printing the exception.