### PR TITLE
PENDING: feat(k3low): move the TIFS ctx address to end of ATF

### DIFF
--- a/plat/ti/k3low/platform.mk
+++ b/plat/ti/k3low/platform.mk
@@ -91,7 +91,7 @@ $(eval $(call add_define,BL32_SIZE))
 PRELOADED_BL33_BASE ?= 0x82000000
 $(eval $(call add_define,PRELOADED_BL33_BASE))
 
-TIFS_LPM_SAVE_CTX ?= 0x81A00000
+TIFS_LPM_SAVE_CTX ?= 0x801fc000
 $(eval $(call add_define,TIFS_LPM_SAVE_CTX))
 
 K3_HW_CONFIG_BASE ?= 0x88000000


### PR DESCRIPTION
As per this new memory map:

```
+-----------+ 0x80000000
|           |
|    TFA    | 1.98 MiB
|           |
+-----------+ 0x801fc000
|           |
|  LPM CTX  | 16 KiB
|           |
+-----------+ 0x80200000
|           |
|    TEE    | 24 MiB
|           |
+-----------+ 0x81a00000
```

Move the TIFS LPM context.

Change-Id: Iac89acb30034bcd62e128f48ea24e166ef15f096

---

Depends on firewall updates to reflect these new regions