### PR TITLE
PENDING: make-helpers: Use -T for linker scripts instead of -Wl,--script

### DIFF
--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -595,7 +595,7 @@ define MAKE_BL
 
         $(eval LINKER_SCRIPT_SOURCES := $($(BL)_LINKER_SCRIPT_SOURCES))
         $(eval LINKER_SCRIPTS := $(call linker_script_path,$(LINKER_SCRIPT_SOURCES)))
-        $(eval GNU_LINKER_ARGS := $(call ld_prefix,-Map=$(MAPFILE)) $(foreach script,$(LINKER_SCRIPTS) $(DEFAULT_LINKER_SCRIPT), $(call ld_prefix,--script $(script))))
+        $(eval GNU_LINKER_ARGS := $(call ld_prefix,-Map=$(MAPFILE)) $(foreach script,$(LINKER_SCRIPTS) $(DEFAULT_LINKER_SCRIPT), $(addprefix -T, $(script))))
 
 $(eval $(call MAKE_OBJS,$(BUILD_DIR),$(SOURCES),$(1),$(BL)))
 


### PR DESCRIPTION
When configured to use picolibc, gcc will insert a default linker script unless another is provided using the -T option. It also always supports -T, so there's no reason to ever use -Wl,--script,

picked from https://github.com/zephyrproject-rtos/trusted-firmware-a/commit/4aef38a5bf03edfa615c1f8af5a49e7065f9fb3f To help enable zephyr builds

Change-Id: Idc22381c78e1bb01ae9bb58a0a7f0fe18f91840f


(cherry picked from commit 44bcc378b6ec4af8693d008f43983e488f1f5740)