### PR TITLE
PENDING: fix(ti): add per-device refcount APIs for A53 core on/off

### DIFF
--- a/drivers/ti/pd/include/ti_device_pm.h
+++ b/drivers/ti/pd/include/ti_device_pm.h
@@ -16,6 +16,7 @@
 #define DEVICE_PM_H
 
 #include <stdbool.h>
+#include <ti_device.h>
 
 struct notifier;
 #define CONFIG_PM
@@ -188,6 +189,20 @@ void ti_device_set_retention(struct ti_device *dev, bool retention);
  *
  */
 void ti_device_clear_flags(struct ti_device *dev);
+
+/**
+ * \brief Set the power up reference for a device by index.
+ *
+ * \param idx The index of the device.
+ */
+void ti_device_id_power_up_ref(dev_idx_t idx);
+
+/**
+ * \brief Drop the power up reference for a device by index.
+ *
+ * \param idx The index of the device.
+ */
+void ti_device_id_drop_power_up_ref(dev_idx_t idx);
 
 /**
  * \brief Set the reset isolation flag for a device.

--- a/drivers/ti/pd/ti_device_pm.c
+++ b/drivers/ti/pd/ti_device_pm.c
@@ -107,6 +107,25 @@ void ti_device_set_state(struct ti_device *device_ptr, uint8_t host_idx, bool en
 	}
 }
 
+void ti_device_id_power_up_ref(dev_idx_t idx)
+{
+	struct ti_device *dev = &soc_devices[idx];
+
+	ti_device_set_state(dev, DEV_POWER_ON_ENABLED_HOST_IDX, true);
+}
+
+void ti_device_id_drop_power_up_ref(dev_idx_t idx)
+{
+	struct ti_device *dev = &soc_devices[idx];
+
+	/* Deinitialize flags only for devices that have been set by a host */
+	if ((dev->flags != 0U) && (dev->initialized != 0U)) {
+		dev->flags = 0U;
+		ti_device_clear_flags(dev);
+		dev->initialized = 0U;
+	}
+}
+
 void ti_device_set_retention(struct ti_device *device_ptr, bool retention)
 {
 	bool is_retention = ((device_ptr->flags & DEV_FLAG_RETENTION) != 0U);

--- a/plat/ti/k3low/common/am62l_psci.c
+++ b/plat/ti/k3low/common/am62l_psci.c
@@ -18,6 +18,7 @@
 #include <k3_console.h>
 #include <ti_devices.h>
 #include <ti_device_handler.h>
+#include <ti_device_pm.h>
 #include <k3_gicv3.h>
 #include <lib/el3_runtime/cpu_data.h>
 #include <lib/mmio.h>
@@ -106,6 +107,7 @@ static int __maybe_unused am62l_core_pwr_domain_on(int core) {
 
 	set_main_psc_state(PD_MPU_CLST_CORE_0 + core, LPSC_MAIN_MPU_CLST_CORE_0 + core,
 			   PSC_PD_ON, PSC_ENABLE);
+	ti_device_id_power_up_ref(AM62LX_DEV_COMPUTE_CLUSTER0_A53_0 + core);
 
 	return PSCI_E_SUCCESS;
 
@@ -150,6 +152,7 @@ static void am62l_pwr_down_domain(const psci_power_state_t *target_state)
 	/* If our cluster is not going down we stop here */
 	if (SYSTEM_PWR_STATE(target_state) != PLAT_MAX_OFF_STATE) {
 		VERBOSE("%s: A53 CORE: %d OFF\n", __func__, core);
+		ti_device_id_drop_power_up_ref(AM62LX_DEV_COMPUTE_CLUSTER0);
 		am62l_core_pwr_domain_off(core);
 	}
 }


### PR DESCRIPTION
Introduce ti_device_id_power_up_ref() and ti_device_id_drop_power_up_ref() to allow incrementing and decrementing the power-on reference count for a device by index, without going through the full TISCI path.

Wire these into am62l_psci.c so that A53 core power-on sets the device power-up reference for AM62LX_DEV_COMPUTE_CLUSTER0_A53_<n>, and core power-down drops the reference for AM62LX_DEV_COMPUTE_CLUSTER0. This ensures the PM subsystem's device state tracking stays consistent with the raw PSC operations used to enable/disable the cores during CPU hotplug and suspend/resume cycles.

This also ensures child devices of their domains work properly like the main_rti0/1

Change-Id: I5d9568a25d42a74044dd17b0088cebf5c32ffe7d