### PR TITLE
TI: Add zephyr module file

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,5 @@
+name: trusted-firmware-a
+
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
When pointing to TI TFA downstream in zephyr west.yml, the zephyr Cmake system requires the TF-A to be decalred as a module.

Describe the TFA downstream as a module using a file named 'zephyr/module.yml'

picked from [`https://github.com/zephyrproject-rtos/trusted-firmware-a/tree/zephyr_tf-a_lts-v2.14#`](url)
To help enable zephyr builds

(cherry picked from commit f4f39af0b30cc383a732e5e8171b7ad3f3b36a34)