### PR TITLE
PENDING: feat(ti): add SMC call to expose wakeup source to Linux

### DIFF
--- a/plat/ti/common/include/k3_sip_svc.h
+++ b/plat/ti/common/include/k3_sip_svc.h
@@ -17,13 +17,14 @@
 #define K3_SIP_OTP_WRITEBUFF    0xC2000000
 #define K3_SIP_OTP_WRITE        0xC2000001
 #define K3_SIP_OTP_READ         0xC2000002
+#define K3_SIP_GET_WKUP_REASON  0xC2000003
 
 /* TI SiP Service Calls version numbers */
 #define K3_SIP_SVC_VERSION_MAJOR	0x0
 #define K3_SIP_SVC_VERSION_MINOR	0x1
 
 /* Number of TI SiP Calls implemented */
-#define K3_COMMON_SIP_NUM_CALLS     0x6
+#define K3_COMMON_SIP_NUM_CALLS     0x7
 
 /* TI Fuse writebuff SMC handler */
 int ti_fuse_writebuff_handler(u_register_t x1);

--- a/plat/ti/common/k3_svc.c
+++ b/plat/ti/common/k3_svc.c
@@ -13,6 +13,7 @@
 
 #include <k3_sip_svc.h>
 #include <lib/mmio.h>
+#include <lpm_stub.h>
 #include <ti_sci.h>
 #include <tools_share/uuid.h>
 
@@ -91,6 +92,10 @@ uintptr_t sip_smc_handler(uint32_t smc_fid,
 		}
 
 		SMC_RET1(handle, SMC_UNK);
+
+	case K3_SIP_GET_WKUP_REASON:
+		SMC_RET4(handle, 0, k3low_get_lpm_mode(), k3low_get_wakeup_src(),
+			 k3low_get_wakeup_pin());
 
 	default:
 		ERROR("%s: unhandled SMC (0x%x)\n", __func__, smc_fid);

--- a/plat/ti/k3low/common/am62l_psci.c
+++ b/plat/ti/k3low/common/am62l_psci.c
@@ -378,6 +378,7 @@ static void am62l_pwr_domain_suspend_finish(const psci_power_state_t *target_sta
 		return;
 	}
 
+	k3low_find_padconf_wakeup_pin();
 	/* Remove the I/O isolation */
 	k3low_lpm_set_io_isolation(false);
 	/* Initialize the console to provide early debug support */

--- a/plat/ti/k3low/common/drivers/lpm/lpm_stub.c
+++ b/plat/ti/k3low/common/drivers/lpm/lpm_stub.c
@@ -78,7 +78,13 @@
 #define RTC_ONLY_PLUS_DDR_MAGIC_WORD		(0x6D555555U)
 #define DEEP_SLEEP_MAGIC_WORD			(0xD5555555U)
 
+#define PADCONF_ADDR	(0x4084000)
+#define NUM_PADCONF_PINS	147U
+#define PADCONF_WKUP_EN		BIT(29)
+#define PADCONF_WKUP_EVT	BIT(30)
+
 #define WAKEUP_UNKNOWN	(0xFFFFFFU)
+#define WAKEUP_PIN_UNKNOWN	(0xFFU)
 
 /* counts of 1us delay for 100ms */
 #define TIMEOUT_100MS					100000U
@@ -110,6 +116,8 @@ __wkupsramdata uint8_t lpm_mode;
 
 static uint32_t k3low_lpm_mode;
 static uint32_t k3low_wakeup_src;
+static uint32_t k3low_wakeup_pin;
+
 extern uint32_t k3low_lpm_switch_stack(uintptr_t jump, uintptr_t stack, uint32_t arg);
 static void k3_lpm_jump_to_stub(uint32_t mode);
 
@@ -672,6 +680,23 @@ void k3low_suspend_to_ram(uint32_t mode)
 	k3_lpm_jump_to_stub(mode);
 }
 
+void k3low_find_padconf_wakeup_pin(void)
+{
+	uint32_t reg;
+	k3low_wakeup_pin = WAKEUP_PIN_UNKNOWN;
+
+	for (int i = 0; i < NUM_PADCONF_PINS; i++) {
+		reg = mmio_read_32(PADCONF_ADDR + i*4);
+		if (!(reg & PADCONF_WKUP_EN))
+			continue;
+
+		if (reg & PADCONF_WKUP_EVT) {
+			k3low_wakeup_pin = i;
+			break;
+		}
+	}
+}
+
 uint32_t k3low_get_lpm_mode(void)
 {
 	return k3low_lpm_mode;
@@ -680,6 +705,11 @@ uint32_t k3low_get_lpm_mode(void)
 uint32_t k3low_get_wakeup_src(void)
 {
 	return k3low_wakeup_src;
+}
+
+uint32_t k3low_get_wakeup_pin(void)
+{
+	return k3low_wakeup_pin;
 }
 
 #ifndef __ASSEMBLER__

--- a/plat/ti/k3low/common/drivers/lpm/lpm_stub.c
+++ b/plat/ti/k3low/common/drivers/lpm/lpm_stub.c
@@ -78,6 +78,8 @@
 #define RTC_ONLY_PLUS_DDR_MAGIC_WORD		(0x6D555555U)
 #define DEEP_SLEEP_MAGIC_WORD			(0xD5555555U)
 
+#define WAKEUP_UNKNOWN	(0xFFFFFFU)
+
 /* counts of 1us delay for 100ms */
 #define TIMEOUT_100MS					100000U
 
@@ -107,18 +109,21 @@ __wkupsramdata uint8_t usb1_state;
 __wkupsramdata uint8_t lpm_mode;
 
 static uint32_t k3low_lpm_mode;
+static uint32_t k3low_wakeup_src;
 extern uint32_t k3low_lpm_switch_stack(uintptr_t jump, uintptr_t stack, uint32_t arg);
 static void k3_lpm_jump_to_stub(uint32_t mode);
 
 void k3low_config_wake_sources(bool enable)
 {
 	uint32_t wake_up_src;
+	k3low_wakeup_src = WAKEUP_UNKNOWN;
 
 	if (enable) {
 		mmio_write_32(WKUP_CTRL_MMR_SEC_5_BASE + WKUP0_EN,
 			      WKUP0_EN_ALL_SOURCES);
 	} else {
 		wake_up_src = mmio_read_32(WKUP_CTRL_MMR_SEC_5_BASE + WKUP0_SRC);
+		k3low_wakeup_src = wake_up_src;
 		mmio_write_32(WKUP_CTRL_MMR_SEC_5_BASE + WKUP0_EN, 0x00);
 		mmio_write_32(WKUP_CTRL_MMR_SEC_5_BASE + WKUP0_SRC, wake_up_src);
 	}
@@ -670,6 +675,11 @@ void k3low_suspend_to_ram(uint32_t mode)
 uint32_t k3low_get_lpm_mode(void)
 {
 	return k3low_lpm_mode;
+}
+
+uint32_t k3low_get_wakeup_src(void)
+{
+	return k3low_wakeup_src;
 }
 
 #ifndef __ASSEMBLER__

--- a/plat/ti/k3low/common/drivers/lpm/lpm_stub.c
+++ b/plat/ti/k3low/common/drivers/lpm/lpm_stub.c
@@ -106,6 +106,7 @@ __wkupsramdata uint8_t usb0_state;
 __wkupsramdata uint8_t usb1_state;
 __wkupsramdata uint8_t lpm_mode;
 
+static uint32_t k3low_lpm_mode;
 extern uint32_t k3low_lpm_switch_stack(uintptr_t jump, uintptr_t stack, uint32_t arg);
 static void k3_lpm_jump_to_stub(uint32_t mode);
 
@@ -662,7 +663,13 @@ __wkupsramfunc void k3low_lpm_resume_c(void)
 
 void k3low_suspend_to_ram(uint32_t mode)
 {
+	k3low_lpm_mode = mode;
 	k3_lpm_jump_to_stub(mode);
+}
+
+uint32_t k3low_get_lpm_mode(void)
+{
+	return k3low_lpm_mode;
 }
 
 #ifndef __ASSEMBLER__

--- a/plat/ti/k3low/common/drivers/lpm/lpm_stub.h
+++ b/plat/ti/k3low/common/drivers/lpm/lpm_stub.h
@@ -70,6 +70,12 @@ int32_t k3low_lpm_set_io_isolation(bool enable);
 __wkupsramfunc void k3low_lpm_abort(void);
 
 /**
+ * @brief Find the pin responsible for latest system wakeup by iterating through PADCONF registers
+ * and checking if WKUP_EVT flag is set
+ */
+void k3low_find_padconf_wakeup_pin(void);
+
+/**
  * @brief Return the last entered low power mode
  *
  * @return last entered low power mode
@@ -82,5 +88,12 @@ uint32_t k3low_get_lpm_mode(void);
  * @return WKUP CTRL MMR WKUP0_SRC register value from the last wakeup
  */
 uint32_t k3low_get_wakeup_src(void);
+
+/**
+ * @brief Return the padconf pin number responsible for the latest system wakeup
+ *
+ * @return wakeup pin number
+ */
+uint32_t k3low_get_wakeup_pin(void);
 
 #endif /* LPM_STB_H */

--- a/plat/ti/k3low/common/drivers/lpm/lpm_stub.h
+++ b/plat/ti/k3low/common/drivers/lpm/lpm_stub.h
@@ -76,4 +76,11 @@ __wkupsramfunc void k3low_lpm_abort(void);
  */
 uint32_t k3low_get_lpm_mode(void);
 
+/**
+ * @brief Return the wakeup source register value captured on resume
+ *
+ * @return WKUP CTRL MMR WKUP0_SRC register value from the last wakeup
+ */
+uint32_t k3low_get_wakeup_src(void);
+
 #endif /* LPM_STB_H */

--- a/plat/ti/k3low/common/drivers/lpm/lpm_stub.h
+++ b/plat/ti/k3low/common/drivers/lpm/lpm_stub.h
@@ -69,4 +69,11 @@ int32_t k3low_lpm_set_io_isolation(bool enable);
  */
 __wkupsramfunc void k3low_lpm_abort(void);
 
+/**
+ * @brief Return the last entered low power mode
+ *
+ * @return last entered low power mode
+ */
+uint32_t k3low_get_lpm_mode(void);
+
 #endif /* LPM_STB_H */


### PR DESCRIPTION
Add an SMC call to let Linux query the wake reason upon resume. This patch is needed since the wake reason interrupt is not forwarded to Linux, so this will allow Linux to parse the wake reason and send the corresponding interrupt needed to that driver.