### PR TITLE
PENDING: feat(ti): add a new SiP service to provide TI-SCI to non-secure hosts

### DIFF
--- a/drivers/ti/ti_sci/ti_sci.c
+++ b/drivers/ti/ti_sci/ti_sci.c
@@ -2179,6 +2179,56 @@ int ti_sci_write_otp(uint8_t bank, uint32_t word, uint32_t val_in, uint32_t mask
 }
 
 /**
+ * ti_sci_xfer_sip() - Forward a TISCI message on behalf of non-secure world
+ *
+ * @req:		Full TISCI transmit message (header + payload) as
+ *			received from the non-secure caller. The message size
+ *			should be in the range
+ *			[sizeof(struct ti_sci_msg_hdr), TI_SCI_MAX_MESSAGE_SIZE]
+ *                      The caller must ensure the req buffer is at least as
+ *			large as MAX(tx_size, rx_size) as the received response
+ *			is also stored in the same buffer in-place.
+ * @tx_size:		Size of tx request in bytes.
+ * @rx_size:		Size of rx response in bytes.
+ *
+ * Builds a fresh TISCI header using ti_sci_setup_one_xfer(), copies the
+ * caller's payload verbatim, then calls ti_sci_do_xfer() which handles
+ * locking, send, and receive.
+ *
+ * Return: 0 on success, else appropriate error code.
+ */
+int ti_sci_xfer_sip(void *req, size_t tx_size, size_t rx_size)
+{
+	struct tisci_msg_generic_sip_req_resp *msg;
+	const struct ti_sci_msg_hdr *in_hdr;
+	struct ti_sci_xfer xfer;
+	int ret;
+
+	if ((req == NULL))
+		return -EINVAL;
+
+	msg = (struct tisci_msg_generic_sip_req_resp *)req;
+	in_hdr = &msg->hdr;
+
+	/*
+	 * Allocate a fresh xfer using TF-A's own sequence counter so that
+	 * ti_sci_get_response() can match the response correctly.
+	 * Catch the response in-place in the same msg buffer.
+	 */
+	ret = ti_sci_setup_one_xfer(in_hdr->type, in_hdr->flags,
+				    msg, tx_size, msg, rx_size,
+				    &xfer);
+	if (ret != 0)
+		return ret;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret != 0)
+		return ret;
+
+	return ret;
+}
+
+/**
  * ti_sci_set_otp_bootmode() - Set OTP boot mode
  *
  * @param index The OTP index to set the boot mode for.

--- a/drivers/ti/ti_sci/ti_sci.h
+++ b/drivers/ti/ti_sci/ti_sci.h
@@ -12,6 +12,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * User exported structures.
@@ -47,6 +48,23 @@ struct ti_sci_msg_version {
  *
  **/
 int ti_sci_get_revision(struct ti_sci_msg_version *version);
+
+/**
+ * ti_sci_xfer_sip() - Forward a TISCI message on behalf of non-secure world
+ *
+ * @req:		Full TISCI transmit message (header + payload) as
+ *			received from the non-secure caller. The message size
+ *			should be in the range
+ *			[sizeof(struct ti_sci_msg_hdr), TI_SCI_MAX_MESSAGE_SIZE]
+ *			The caller must ensure the req buffer is at least as
+ *			large as MAX(tx_size, rx_size) as the received response
+ *			is also stored in the same buffer in-place.
+ * @tx_size:		Size of tx request in bytes.
+ * @rx_size:		Size of rx response in bytes.
+ *
+ * Return: 0 on success, else appropriate error code.
+ */
+int ti_sci_xfer_sip(void *req, size_t tx_size, size_t rx_size);
 
 /**
  * Device control operations

--- a/drivers/ti/ti_sci/ti_sci_protocol.h
+++ b/drivers/ti/ti_sci/ti_sci_protocol.h
@@ -60,6 +60,9 @@
 #define TI_SCI_MSG_FWL_GET		0x9001
 #define TI_SCI_MSG_FWL_CHANGE_OWNER	0x9002
 
+/* Runtime Debug Messages */
+#define TISCI_MSG_GET_SOC_UID		0x9021
+
 /* OTP MMR messages */
 #define TISCI_MSG_READ_OTP_MMR		0x9022
 #define TISCI_MSG_WRITE_OTP_MMR 	0x9023
@@ -1138,6 +1141,11 @@ struct tisci_msg_set_otp_bootmode_req {
  */
 struct tisci_msg_set_otp_bootmode_resp {
 	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+struct tisci_msg_generic_sip_req_resp {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t msg[TI_SCI_MAX_MESSAGE_SIZE - sizeof(struct ti_sci_msg_hdr)];
 } __packed;
 
 #endif /* TI_SCI_PROTOCOL_H */

--- a/plat/ti/common/include/k3_sip_svc.h
+++ b/plat/ti/common/include/k3_sip_svc.h
@@ -18,16 +18,21 @@
 #define K3_SIP_OTP_WRITE        0xC2000001
 #define K3_SIP_OTP_READ         0xC2000002
 #define K3_SIP_GET_WKUP_REASON  0xC2000003
+#define K3_SIP_TISCI_XFER       0xC2000004
 
 /* TI SiP Service Calls version numbers */
 #define K3_SIP_SVC_VERSION_MAJOR	0x0
 #define K3_SIP_SVC_VERSION_MINOR	0x1
 
 /* Number of TI SiP Calls implemented */
-#define K3_COMMON_SIP_NUM_CALLS     0x7
+#define K3_COMMON_SIP_NUM_CALLS     0x8
 
 /* TI Fuse writebuff SMC handler */
 int ti_fuse_writebuff_handler(u_register_t x1);
+
+/* Generic TISCI proxy SMC handler */
+int ti_sci_xfer_sip_handler(size_t tx_size, size_t rx_size,
+			    uint64_t *msg, uint8_t *res);
 
 #endif /* K3_SIP_SVC_H */
 

--- a/plat/ti/common/k3_sip_handler.c
+++ b/plat/ti/common/k3_sip_handler.c
@@ -1,8 +1,10 @@
 /*
- * Copyright (c) 2025, Texas Instruments. All rights reserved.
+ * Copyright (c) 2025-2026, Texas Instruments. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+#include <errno.h>
 
 #include <ti_platform_defs.h>
 #include <arch_helpers.h>
@@ -68,6 +70,100 @@ int ti_fuse_writebuff_handler(u_register_t x1)
 		ERROR("Invalid TISCI ID (0x%x)\n", k3_fuse_buff->tisci_id);
 		return SMC_UNK;
 	}
+
+	return 0;
+}
+
+/*
+ * This is a list of TI_SCI messages which are exposed to non-secure users
+ * through this SiP service. The SiP call with any other message type will
+ * return -EPERM.
+ * Expand the list as necessary.
+ */
+static const uint16_t allowed_sip_ti_sci_msg_types[] = {
+	/* General */
+	TI_SCI_MSG_VERSION,
+
+	/* Security - Processor Boot */
+	TISCI_MSG_PROC_AUTH_BOOT_IMAGE,
+
+	/* Security - Runtime Debug */
+	TISCI_MSG_GET_SOC_UID,
+};
+
+static bool ti_sip_is_ti_sci_call_allowed(uint16_t msg_type)
+{
+	for (int i = 0; i < ARRAY_SIZE(allowed_sip_ti_sci_msg_types); ++i) {
+		if (msg_type == allowed_sip_ti_sci_msg_types[i])
+			return true;
+	}
+	return false;
+}
+
+/**
+ * ti_sci_xfer_sip_handler - Forward a TISCI message from non-secure world via SiP SMC.
+ *
+ * @tx_size:     Size of the transmit message in bytes. Must be in the range
+ *               [sizeof(TISCI header), TI_SCI_MAX_MESSAGE_SIZE].
+ * @rx_size:     Size of the receive message in bytes. Must be in the range
+ *               [sizeof(TISCI header), TI_SCI_MAX_MESSAGE_SIZE].
+ * @msg:         The message itself, serialized from the 64-bit SMC registers.
+ *               The caller needs to ensure that the length of this buffer is at
+ *               least tx_size in length.
+ * @res:         Buffer to store the response. Response is passed on to the caller
+ *               through this buffer. Hence it is the responsibility of the caller
+ *               to ensure the size of this buffer is at least rx_size.
+ *
+ * TF-A copies the message to a local stack buffer, does the TISCI xfer, then
+ * copies the response back to the caller's buffer.
+ *
+ * Return: 0 on success, negative errno on error.
+ */
+int ti_sci_xfer_sip_handler(size_t tx_size, size_t rx_size,
+			    uint64_t *msg, uint8_t *res)
+{
+	uint8_t req[TI_SCI_MAX_MESSAGE_SIZE];
+	struct ti_sci_msg_hdr *hdr;
+	int ret;
+
+	/*
+	 * The message header on non-secure host does not contain
+	 * secure header. This is prepended in the TF-A. Add its
+	 * size to msg size.
+	 */
+	size_t secure_tx_size = tx_size + sizeof(struct ti_sci_secure_msg_hdr);
+	size_t secure_rx_size = rx_size + sizeof(struct ti_sci_secure_msg_hdr);
+
+	if (secure_tx_size > TI_SCI_MAX_MESSAGE_SIZE ||
+	    secure_tx_size < sizeof(struct ti_sci_msg_hdr) ||
+	    secure_rx_size > TI_SCI_MAX_MESSAGE_SIZE ||
+	    secure_rx_size < sizeof(struct ti_sci_msg_hdr)) {
+		ERROR("ERROR: Invalid TISCI message size\n");
+		return -ERANGE;
+	}
+
+	/* Leave space for secure header at the beginning. */
+	memcpy(req + sizeof(struct ti_sci_secure_msg_hdr), msg, tx_size);
+
+	hdr = (struct ti_sci_msg_hdr *)req;
+
+	if (!ti_sip_is_ti_sci_call_allowed(hdr->type)) {
+		ERROR("TISCI Message %u is not allowed/supported\n",
+		      hdr->type);
+		return -EPERM;
+	}
+
+	ret = ti_sci_xfer_sip(req, secure_tx_size, secure_rx_size);
+	if (ret != 0) {
+		ERROR("Error: TISCI transfer failed (%d)\n", ret);
+		return ret;
+	}
+
+	/*
+	 * Write response back to the caller's buffer. Remove secure header as
+	 * non-secure hosts do not expect it.
+	 */
+	memcpy(res, req + sizeof(struct ti_sci_secure_msg_hdr), rx_size);
 
 	return 0;
 }

--- a/plat/ti/common/k3_svc.c
+++ b/plat/ti/common/k3_svc.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <errno.h>
 
 #include <common/debug.h>
 #include <common/runtime_svc.h>
@@ -35,6 +36,13 @@ uintptr_t sip_smc_handler(uint32_t smc_fid,
 			  u_register_t flags)
 {
 	int ret = SMC_UNK;
+	u_register_t x5, x6, x7, x8, x9;
+
+	x5 = SMC_GET_GP(handle, CTX_GPREG_X5);
+	x6 = SMC_GET_GP(handle, CTX_GPREG_X6);
+	x7 = SMC_GET_GP(handle, CTX_GPREG_X7);
+	x8 = SMC_GET_GP(handle, CTX_GPREG_X8);
+	x9 = SMC_GET_GP(handle, CTX_GPREG_X9);
 
 	switch (smc_fid) {
 	case SIP_SVC_CALL_COUNT:
@@ -96,6 +104,21 @@ uintptr_t sip_smc_handler(uint32_t smc_fid,
 	case K3_SIP_GET_WKUP_REASON:
 		SMC_RET4(handle, 0, k3low_get_lpm_mode(), k3low_get_wakeup_src(),
 			 k3low_get_wakeup_pin());
+
+	case K3_SIP_TISCI_XFER:
+		{
+			size_t tx_size = (size_t)x1;
+			size_t rx_size = (size_t)x2;
+			uint64_t msg[] = { x3, x4, x5, x6, x7, x8, x9 };
+			uint64_t res[DIV_ROUND_UP_2EVAL(TI_SCI_MAX_MESSAGE_SIZE, sizeof(uint64_t))];
+
+			ret = ti_sci_xfer_sip_handler(tx_size, rx_size, msg, (uint8_t *)res);
+			if (ret)
+				SMC_RET1(handle, ret);
+
+			SMC_RET8(handle, ret, res[0], res[1], res[2],
+				 res[3], res[4], res[5], res[6]);
+		}
 
 	default:
 		ERROR("%s: unhandled SMC (0x%x)\n", __func__, smc_fid);


### PR DESCRIPTION
Add a new SiP service for TI SoCs, aimed particularly at AM62L. AM62L does not have a dedicated mailbox channel allocated for non-secure hosts. Due to this, non-secure hosts on A53 like U-Boot and Linux cannot make TISCI calls to TI-FS. Mitigate this by routing the TISCI calls through TF-A using SVC.

The API this SiP SMC call expects is:
x1: size of the tx message
x2: size of the rx message
x3 - x9: tx message de-serialized into 8-byte chunks, one in each register

Since we are requiring use of 10 SMC registers (x0 to x9), SMCCC v1.2+ is required, which expands input and output registers available to 18.

The SiP call design expects the tx message passed to be in the TISCI API format (without the secure header): 8 byte message header followed by 44 byte payload. This is basically the same buffer passed on to mailbox or secure proxy in the typical ti_sci_do_xfer() functions. This keeps the required changes in non-secure hosts minimal; only a different implementation of ti_sci_do_xfer() is needed which calls arm_smccc_1_2_smc() instead of passing the message to the mailbox.

Change-Id: I609a7c16cf2e4aac87e620e9f9d17358af106e9e