### PR TITLE
UPSTREAM: fix(ti): correct bypass logic in 16FFT PLL driver

### DIFF
--- a/drivers/ti/clk/ti_clk_pll_16fft.c
+++ b/drivers/ti/clk/ti_clk_pll_16fft.c
@@ -500,7 +500,7 @@ static int32_t clk_pll_16fft_bypass(struct ti_clk *clock_ptr, bool bypass)
 	if (bypass && ((ctrl & PLL_16FFT_CTRL_BYPASS_EN) == 0U)) {
 		ctrl |= PLL_16FFT_CTRL_BYPASS_EN;
 		pll_16fft_write(pll, PLL_16FFT_CTRL, ctrl);
-	} else if ((ctrl & PLL_16FFT_CTRL_BYPASS_EN) == PLL_16FFT_CTRL_BYPASS_EN) {
+	} else if (!bypass && ((ctrl & PLL_16FFT_CTRL_BYPASS_EN) == PLL_16FFT_CTRL_BYPASS_EN)) {
 		/* Disable bypass only if its bypassed */
 		ctrl &= (uint32_t)~PLL_16FFT_CTRL_BYPASS_EN;
 		pll_16fft_write(pll, PLL_16FFT_CTRL, ctrl);


### PR DESCRIPTION
commit 49c6b8f476d813cc57579c71225c91cc7b09ac55 upstream

The ti_clk_pll_16fft_bypass() function had a logical error in the else-if condition. The condition was checking only if bypass is currently enabled, but not verifying that the caller actually wants to disable bypass.

This caused incorrect behavior where calling bypass(pll, true) when bypass is already enabled would unexpectedly disable bypass instead of leaving it enabled.

Change-Id: Ib208cc0df0598079fd98378cfcf7efd492f91fa7