### PR TITLE
UPSTREAM: fix(ti/clk): fix false success in ti_clk_div_set_freq_static…

### DIFF
--- a/drivers/ti/clk/ti_clk_div.c
+++ b/drivers/ti/clk/ti_clk_div.c
@@ -327,7 +327,7 @@ uint32_t ti_clk_div_set_freq_static_parent(struct ti_clk *clkp, uint32_t target_
 	div1_hz = 0U;
 	if (div1 <= n) {
 		div1_hz = parent_freq_hz / div1;
-		if (div1_hz >= min_hz) {
+		if ((div1_hz >= min_hz) && (div1_hz <= max_hz)) {
 			div1_ok = true;
 			div1_delta = target_hz - div1_hz;
 		} else {


### PR DESCRIPTION
…_parent

ti_clk_div_set_freq_static_parent() searches two candidate dividers: div0 = floor(parent_freq / target_hz) and div1 = div0 + 1.

The div1 range check only tests the lower bound (div1_hz >= min_hz) with no upper bound check. When the ideal divider exceeds max_div, div0 is clamped to max_div - 1 and div1 = max_div. Both candidates now produce a frequency above the target. The missing upper bound on div1 causes div1_hz > target_hz to pass the check when called with min_hz = max_hz = target_hz, making the function return a false success. The caller in clk_pll_16fft_hsdiv_set_freq then exits early without reprogramming the PLL VCO to reach the requested frequency.

Add the missing div1_hz <= max_hz check. The lower bound check on div0 is not needed since div0 is the floor divider, guaranteeing div0_hz >= target_hz >= min_hz by construction.